### PR TITLE
Fix and normalise table colours

### DIFF
--- a/ml_peg/app/utils/build_components.py
+++ b/ml_peg/app/utils/build_components.py
@@ -10,9 +10,9 @@ from dash.development.base_component import Component
 from dash.html import H2, H3, Br, Button, Details, Div, Label, Summary
 
 from ml_peg.app.utils.register_callbacks import (
+    register_category_table_callbacks,
     register_normalization_callbacks,
     register_summary_table_callbacks,
-    register_tab_table_callbacks,
     register_weight_callbacks,
 )
 from ml_peg.app.utils.utils import calculate_column_widths
@@ -112,7 +112,7 @@ def build_weight_components(
     header: str,
     table: DataTable,
     *,
-    use_threshold_store: bool = False,
+    use_thresholds: bool = False,
     column_widths: dict[str, int] | None = None,
 ) -> Div:
     """
@@ -124,7 +124,7 @@ def build_weight_components(
         Header for above sliders.
     table
         DataTable to build weight components for.
-    use_threshold_store
+    use_thresholds
         Whether this table also exposes normalization thresholds. When True,
         weight callbacks will reuse the raw-data store and normalization store to
         recompute Scores consistently.
@@ -253,8 +253,8 @@ def build_weight_components(
 
     # Callbacks to update table scores when table weight dicts change
     if table.id != "summary-table":
-        register_tab_table_callbacks(
-            table_id=table.id, use_threshold_store=use_threshold_store
+        register_category_table_callbacks(
+            table_id=table.id, use_thresholds=use_thresholds
         )
     else:
         register_summary_table_callbacks()
@@ -368,7 +368,7 @@ def build_test_layout(
     metric_weights = build_weight_components(
         header="Metric Weights",
         table=table,
-        use_threshold_store=(thresholds is not None),
+        use_thresholds=True,
         column_widths=column_widths,
     )
     if metric_weights:

--- a/ml_peg/app/utils/load.py
+++ b/ml_peg/app/utils/load.py
@@ -9,7 +9,7 @@ from dash.dash_table import DataTable
 from dash.dcc import Graph
 from plotly.io import read_json
 
-from ml_peg.analysis.utils.utils import get_table_style
+from ml_peg.analysis.utils.utils import calc_metric_scores, get_table_style
 from ml_peg.app.utils.utils import (
     calculate_column_widths,
     clean_thresholds,
@@ -59,7 +59,8 @@ def rebuild_table(filename: str | Path, id: str) -> DataTable:
             column.setdefault("format", sig_fig_format())
     tooltip_header = table_json["tooltip_header"]
 
-    style = get_table_style(data)
+    scored_data = calc_metric_scores(data)
+    style = get_table_style(data, scored_data=scored_data)
     column_widths = calculate_column_widths([cols["name"] for cols in columns])
 
     style_cell_conditional: list[dict[str, object]] = []

--- a/ml_peg/app/utils/register_callbacks.py
+++ b/ml_peg/app/utils/register_callbacks.py
@@ -61,8 +61,8 @@ def register_summary_table_callbacks() -> None:
         return update_score_rank_style(summary_data, stored_weights)
 
 
-def register_tab_table_callbacks(
-    table_id: str, use_threshold_store: bool = False
+def register_category_table_callbacks(
+    table_id: str, use_thresholds: bool = False
 ) -> None:
     """
     Register callback to update table scores/rankings when stored values change.
@@ -71,12 +71,13 @@ def register_tab_table_callbacks(
     ----------
     table_id
         ID for table to update.
-    use_threshold_store
+    use_thresholds
         If `True`, also watch the per-metric normalization store and recompute
         scores using the configured thresholds. This should only be used for benchmark
         tables.
     """
-    if use_threshold_store:
+    # Benchmark tables
+    if use_thresholds:
 
         @callback(
             Output(table_id, "data", allow_duplicate=True),
@@ -91,7 +92,7 @@ def register_tab_table_callbacks(
             State(f"{table_id}-computed-store", "data"),
             prevent_initial_call="initial_duplicate",
         )
-        def update_table_scores_with_thresholds(
+        def update_benchmark_table_scores(
             stored_weights: dict[str, float] | None,
             stored_threshold: dict | None,
             _tabs_value: str,
@@ -132,7 +133,8 @@ def register_tab_table_callbacks(
                 display_rows = get_scores(
                     stored_raw_data, stored_computed_data, thresholds, toggle_value
                 )
-                style = get_table_style(display_rows)
+                scored_rows = calc_metric_scores(stored_raw_data, thresholds=thresholds)
+                style = get_table_style(display_rows, scored_data=scored_rows)
                 return display_rows, style, stored_computed_data, stored_raw_data
 
             # Update overall table score for new weights and thresholds
@@ -145,7 +147,7 @@ def register_tab_table_callbacks(
             display_rows = get_scores(
                 metrics_data, scored_rows, thresholds, toggle_value
             )
-            style = get_table_style(display_rows)
+            style = get_table_style(display_rows, scored_data=scored_rows)
             return display_rows, style, scored_rows, metrics_data
 
     else:
@@ -480,7 +482,7 @@ def register_normalization_callbacks(
             display_rows = get_scores(
                 raw_data, scored_rows, thresholds, show_normalized
             )
-            style = get_table_style(display_rows)
+            style = get_table_style(display_rows, scored_data=scored_rows)
             return display_rows, style
 
     # Register individual threshold input sync callbacks


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Updates table colours to default to span between 0 and 1 for all non-rank columns.

For metrics with thresholds, as discussed in #108, we use the normalised versions of the metrics, which requires passing in both sets of values, as the normalised scores are give us the colour, but we need to filter by the displayed value.

Also required additional logic to flip the text colour correctly, depending on the order of the colour system.

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #108

## Testing

Test with all models/tests currently on main.