### PR TITLE
Merge weights and thresholds boxes

### DIFF
--- a/ml_peg/app/utils/build_components.py
+++ b/ml_peg/app/utils/build_components.py
@@ -498,17 +498,16 @@ def build_test_layout(
         # Combine threshold and weight panels in a single card while trimming the extra
         # <Br/> injected at the top of the weight component so the boundary box hugs
         # both controls.
+        # The first child of the weight component is always the spacer <Br/> returned by
+        # build_weight_components. Drop it from the weights so the metric weights box
+        # hugs the threshold box.
         weight_children = metric_weights.children
-        if isinstance(weight_children, tuple | list):
-            weight_children = list(weight_children)
-        elif weight_children is None:
-            weight_children = []
-        else:
-            weight_children = [weight_children]
-        if weight_children and isinstance(weight_children[0], Br):
-            weight_children = weight_children[1:]
+        weight_children = weight_children[1:]
         compact_weights = Div(weight_children)
 
+        # Insert a single spacer before the combined card so its top aligns with the
+        # elements above (e.g. the table). The thresholds + weights content then sit
+        # within the shared box.
         layout_contents.append(Br())
         layout_contents.append(
             Div(


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

<!-- Describe your proposed changes. This can be brief, as most information can be in the linked issue. -->
Merge the weights and metrics boxes into what appears to be one box. They are still in separate boxes, just with invisible borders, and now with a larger box (with a visible border) under neath. this was the best appraoch i found for modularity. also made some paddng and margins more consistent and made the boxes more compact.
## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #123 

## Testing
run the app
<!-- How have your proposed changes been tested? -->
