### PR TITLE
Remove deepcopy from S24

### DIFF
--- a/ml_peg/calcs/surfaces/S24/calc_S24.py
+++ b/ml_peg/calcs/surfaces/S24/calc_S24.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from copy import deepcopy
+from copy import copy
 from pathlib import Path
 
 from ase import Atoms
@@ -72,7 +72,7 @@ class S24Benchmark(zntrack.Node):
             Calculator to use to evaluate structure energy.
         """
         for atoms in atoms_list:
-            atoms.calc = deepcopy(calc)
+            atoms.calc = copy(calc)
             atoms.get_potential_energy()
 
     def run(self):


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Replaced `deepcopy` with `copy` for S24 calculator, which was consuming huge amounts of memory, making running larger models e.g. UMA medium unfeasible 

Tested locally