### PR TITLE
Fix D3 correction for r2SCAN model

### DIFF
--- a/ml_peg/models/models.yml
+++ b/ml_peg/models/models.yml
@@ -48,6 +48,8 @@ mace-matpes-r2scan:
   kwargs:
     model: "mace-matpes-r2scan-0"
     head: "matpes_pbe"
+  d3_kwargs:
+    xc: r2scan
 
 # mace-mh-1-omat:
 #   module: mace.calculators


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

When adding the `TorchDFTD3Calculator`, the functional should match that of the model. In all other cases where we add dispersion, this is PBE, but for r2SCAN, it should be D4, which is set via `xc=r2scan` (see: https://github.com/pfnet-research/torch-dftd/pull/29)

## Testing

Tested for mace-matpes-r2scan
