### PR TITLE
Fix order of structures for GMTKN55

### DIFF
--- a/ml_peg/app/molecular/GMTKN55/app_GMTKN55.py
+++ b/ml_peg/app/molecular/GMTKN55/app_GMTKN55.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from dash import Dash
 from dash.html import Div
 
@@ -31,7 +33,9 @@ class GMTKN55App(BaseApp):
         structs_dir = DATA_PATH / MODELS[0]
         structs = [
             f"assets/molecular/GMTKN55/{MODELS[0]}/{struct_file.stem}.xyz"
-            for struct_file in sorted(structs_dir.glob("*.xyz"))
+            for struct_file in sorted(
+                structs_dir.glob("*.xyz"), key=lambda f: int(Path(f).stem)
+            )
         ]
 
         plot_from_table_column(


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Resolves ordering of structures for GMTKN55, as these written in numerical order, but the app was then sorting lexicographically.

This also helps explain the anomalous 0s described in the linked issue. These are in most, if not all, cases, structures that are identical, but with difference charges, leading to identical predictions for models that do not handle this.

This was not obvious due to the incorrect structures being visualised.

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #246

## Testing

Tested with mace-mp-0a.
