### PR TITLE
Track viewer analytics

### DIFF
--- a/ml_peg/app/run_app.py
+++ b/ml_peg/app/run_app.py
@@ -10,6 +10,7 @@ from dash import Dash
 from ml_peg.app.build_app import build_full_app
 
 DATA_PATH = Path(__file__).parent / "data"
+ANALYTICS_ID = os.environ.get("ML_PEG_ANALYTICS_ID")
 
 
 def _build_full_app(app: Dash, category: str, test: str):
@@ -28,13 +29,39 @@ def _build_full_app(app: Dash, category: str, test: str):
     build_full_app(app, category, test)
 
 
+# Load the async gtag script in <head> only when an analytics ID is configured
+_analytics_scripts = (
+    [
+        {
+            "src": f"https://www.googletagmanager.com/gtag/js?id={ANALYTICS_ID}",
+            "async": True,
+        }
+    ]
+    if ANALYTICS_ID
+    else []
+)
+
 # Make server accessible for gunicorn
 app = Dash(
     __name__,
     assets_folder=DATA_PATH,
     title="ML-PEG",  # set browser tab title
     update_title=None,  # prevent the tab changing to Updating... during callbacks
+    external_scripts=_analytics_scripts,
 )
+
+# Inject the inline gtag init into the parsed <head> so the browser executes it
+if ANALYTICS_ID:
+    app.index_string = app.index_string.replace(
+        "{%metas%}",
+        "{%metas%}\n"
+        "    <script>"
+        "window.dataLayer=window.dataLayer||[];"
+        "function gtag(){dataLayer.push(arguments);}"
+        "gtag('js', new Date());"
+        f"gtag('config', '{ANALYTICS_ID}');"
+        "</script>",
+    )
 
 # Only build app when in production, otherwise run_app's layout is missing
 if bool(os.environ.get("ML_PEG_PROD", False)):


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary
The app builder now looks for an analytics measurement ID (ML_PEG_ANALYTICS_ID) when assembling the Dash layout. If set, build_full_app calls a helper that generates the standard gtag.js script tags for that ID and appends them to the root layout so they load on every page. This keeps the tracking snippet out of the repo while letting you enable GA by simply exporting the env var on the VM.
<!-- Describe your proposed changes. This can be brief, as most information can be in the linked issue. -->

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #269 

## Testing
None so far
<!-- How have your proposed changes been tested? -->
