### PR TITLE
Remove coverage from pytest default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         env:
           # show timings of tests
           PYTEST_ADDOPTS: "--durations=0"
-        run: uv run pytest --cov ml_peg --cov-append .
+        run: uv run pytest --cov ml_peg --cov-append . --cov-report xml
 
       - name: Report coverage to Coveralls
         uses: coverallsapp/github-action@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ build-backend = "uv_build"
 [tool.pytest.ini_options]
 # Configuration for [pytest](https://docs.pytest.org)
 python_files = "test_*.py"
-addopts = '--cov-report xml'
 pythonpath = ["."]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Removes default `--cov-report` option from `pytest`, as this is only installed as part of the dev dependencies, meaning if you `pip install ml-peg` it would be missing, resulting in `ml_peg calc` and `ml_peg analyse` throwing errors.

## Testing

Tested locally
