### PR TITLE
Handle missing graph files on load

### DIFF
--- a/ml_peg/app/utils/load.py
+++ b/ml_peg/app/utils/load.py
@@ -225,7 +225,8 @@ def read_plot(filename: str | Path, id: str = "figure-1") -> Graph:
     Graph
         Loaded plotly Graph.
     """
-    return Graph(id=id, figure=read_json(filename))
+    figure = read_json(filename) if Path(filename).exists() else None
+    return Graph(id=id, figure=figure)
 
 
 def _filter_density_figure_for_model(fig_dict: dict, model: str) -> dict:


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Currently, if a graph fails to load e.g. due to the file being missing for a specific model, an error will be raised.

This returns `None` instead, making it more robust.

## Testing

Tested locally (NEBs raise an error due to missing omol graphs)
