### PR TITLE
Added 2D TMDs NEB benchmark and docs updates

### DIFF
--- a/docs/source/user_guide/benchmarks/nebs.rst
+++ b/docs/source/user_guide/benchmarks/nebs.rst
@@ -47,7 +47,6 @@ Reference data:
 * Manually taken from https://doi.org/10.1149/1.1633511.
 * Meta-GGA (Perdew-Wang) exchange correlation functional
 
-
 Si defects
 ==========
 
@@ -103,3 +102,58 @@ Input/reference data:
   - 64 atoms: Γ-only (``K_POINTS automatic 1 1 1 0 0 0``)
   - 216 atoms: Γ-only (``K_POINTS gamma``)
   - 216 atoms di-to-single: Γ-only (``K_POINTS gamma``)
+
+Oxygen adatom diffusion on 2D TMDs
+==================================
+
+Summary
+-------
+
+Performance in predicting diffusion barriers for oxygen adatom migration on monolayer 2D transition metal dichalcogenide (TMD) surfaces.
+
+Metrics
+-------
+
+1. Diffusion barrier error
+
+The diffusion barrier is defined as the maximum energy along the NEB minimum energy path (MEP), relative to the initial state energy. This is compared to the reference DFT-PBE calculated barrier for each material.
+
+The benchmark includes the following 2D TMD materials (2H phase):
+
+* MoS₂
+* MoSe₂
+* MoTe₂
+* WS₂
+* WSe₂
+* WTe₂
+
+Computational cost
+------------------
+
+Medium: tests involving multiple foundation models are likely to take around an one hour to run on a single GPU.
+
+Data availability
+-----------------
+
+Input structures:
+
+* Primitive cells can downloaded from the Materials Project (2H bulk structures):
+
+  - MoS₂: mp-2815 https://legacy.materialsproject.org/materials/mp-2815/
+  - MoSe₂: mp-1634 https://legacy.materialsproject.org/materials/mp-1634/
+  - MoTe₂: mp-602 https://legacy.materialsproject.org/materials/mp-602/
+  - WS₂: mp-224 https://legacy.materialsproject.org/materials/mp-224/
+  - WSe₂: mp-1821 https://legacy.materialsproject.org/materials/mp-1821/
+  - WTe₂: mp-1019322 https://legacy.materialsproject.org/materials/mp-1019322/
+
+* Chalcogen-chalcogen thicknesses extracted from these bulk structures by computing intra-layer vertical separations.
+* In-plane lattice constants manually extracted from Liu et al. (see reference data below):
+    - MoS₂ 3.183 Å, MoSe₂ 3.318 Å, MoTe₂ 3.547 Å, WS₂ 3.182 Å, WSe₂ 3.317 Å, WTe₂ 3.551 Å.
+* Monolayer 6x6x1 supercells built using ASE ``build.mx2`` (https://wiki.fysik.dtu.dk/ase/ase/build/surface.html#ase.build.mx2) using the lattice constants and thicknesses reported here.
+* End pairs created by placing an oxygen adatom in adjacent sites with initial heights of around 1.5-1.7 Å depending on the chalcogen atom.
+* Structures are then relaxed by the foundation model being tested.
+
+Reference data:
+
+* Manually taken from https://doi.org/10.1039/C4RA17320A
+* GGA (PBE) exchange correlation functional

--- a/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/analyse_O_diffusion_2D_TMDs.py
+++ b/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/analyse_O_diffusion_2D_TMDs.py
@@ -1,0 +1,199 @@
+"""Analyse O diffusion on 2D TMDs benchmark."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ase.io import read, write
+import pytest
+
+from ml_peg.analysis.utils.decorators import build_table, plot_scatter
+from ml_peg.analysis.utils.utils import load_metrics_config
+from ml_peg.app import APP_ROOT
+from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models.get_models import get_model_names
+from ml_peg.models.models import current_models
+
+MODELS = get_model_names(current_models)
+CALC_PATH = CALCS_ROOT / "nebs" / "O_diffusion_2D_TMDs" / "outputs"
+OUT_PATH = APP_ROOT / "data" / "nebs" / "O_diffusion_2D_TMDs"
+
+METRICS_CONFIG_PATH = Path(__file__).with_name("metrics.yml")
+DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
+    METRICS_CONFIG_PATH
+)
+
+# Reference DFT-PBE barriers from Liu et al. (eV)
+REF_VALUES = {
+    "MoS2": 2.53,
+    "MoSe2": 1.55,
+    "MoTe2": 0.90,
+    "WS2": 2.68,
+    "WSe2": 1.66,
+    "WTe2": 1.01,
+}
+
+COMPOUNDS = ["MoS2", "MoSe2", "MoTe2", "WS2", "WSe2", "WTe2"]
+
+
+def plot_nebs(model: str, compound: str) -> None:
+    """
+    Plot NEB paths and save all structure files.
+
+    Parameters
+    ----------
+    model
+        Name of MLIP.
+    compound
+        TMD compound name.
+    """
+
+    @plot_scatter(
+        filename=OUT_PATH / f"figure_{model}_O_diffusion_{compound}.json",
+        title=f"O diffusion on {compound}",
+        x_label="Image",
+        y_label="Energy / eV",
+        show_line=True,
+    )
+    def plot_neb() -> dict[str, tuple[list[float], list[float]]]:
+        """
+        Plot a NEB and save the structure file.
+
+        Returns
+        -------
+        dict[str, tuple[list[float], list[float]]]
+            Dictionary of tuples of image/energy for each model.
+        """
+        results: dict[str, tuple[list[float], list[float]]] = {}
+        structs = read(
+            CALC_PATH / f"O_diffusion_{compound}-{model}-neb-band.extxyz",
+            index=":",
+        )
+        energies = [struct.get_potential_energy() for struct in structs]
+        results[model] = (
+            list(range(len(structs))),
+            energies,
+        )
+        structs_dir = OUT_PATH / model
+        structs_dir.mkdir(parents=True, exist_ok=True)
+        write(structs_dir / f"{model}-{compound}-neb-band.extxyz", structs)
+
+        return results
+
+    plot_neb()
+
+    # Add a horizontal reference line at initial energy + ref barrier
+    fig_path = OUT_PATH / f"figure_{model}_O_diffusion_{compound}.json"
+    if fig_path.exists():
+        with open(fig_path, encoding="utf8") as f:
+            fig = json.load(f)
+
+        structs = read(
+            CALC_PATH / f"O_diffusion_{compound}-{model}-neb-band.extxyz",
+            index=":",
+        )
+        y0 = structs[0].get_potential_energy()
+        y_ref = y0 + REF_VALUES[compound]
+
+        layout = fig.setdefault("layout", {})
+        shapes = layout.setdefault("shapes", [])
+        shapes.append(
+            {
+                "type": "line",
+                "xref": "paper",
+                "yref": "y",
+                "x0": 0,
+                "x1": 1,
+                "y0": y_ref,
+                "y1": y_ref,
+                "line": {"color": "red", "width": 1, "dash": "dash"},
+            }
+        )
+
+        # Add legend entry for the reference line
+        data = fig.setdefault("data", [])
+        data.append(
+            {
+                "type": "scatter",
+                "mode": "lines",
+                "name": "Reference barrier",
+                "x": [0, 1],
+                "y": [y_ref, y_ref],
+                "line": {"color": "red", "width": 1, "dash": "dash"},
+                "hoverinfo": "skip",
+                "showlegend": True,
+                "xaxis": "x",
+                "yaxis": "y",
+            }
+        )
+
+        with open(fig_path, "w", encoding="utf8") as f:
+            json.dump(fig, f)
+
+
+@pytest.fixture
+def barrier_errors() -> dict[str, dict[str, float]]:
+    """
+    Get error in diffusion barriers for all compounds.
+
+    Returns
+    -------
+    dict[str, dict[str, float]]
+        Dictionary of predicted barrier errors for all models and compounds.
+    """
+    OUT_PATH.mkdir(parents=True, exist_ok=True)
+    results: dict[str, dict[str, float]] = {model: {} for model in MODELS}
+
+    for model_name in MODELS:
+        for compound in COMPOUNDS:
+            plot_nebs(model_name, compound)
+            with open(
+                CALC_PATH / f"O_diffusion_{compound}-{model_name}-neb-results.dat",
+                encoding="utf8",
+            ) as f:
+                data = f.readlines()
+                pred_barrier, _, _ = tuple(float(x) for x in data[1].split())
+            results[model_name][compound] = abs(REF_VALUES[compound] - pred_barrier)
+
+    return results
+
+
+@pytest.fixture
+@build_table(
+    filename=OUT_PATH / "O_diffusion_metrics_table.json",
+    metric_tooltips=DEFAULT_TOOLTIPS,
+    thresholds=DEFAULT_THRESHOLDS,
+)
+def metrics(barrier_errors: dict[str, dict[str, float]]) -> dict[str, dict]:
+    """
+    Get all O diffusion metrics.
+
+    Parameters
+    ----------
+    barrier_errors
+        Diffusion barrier errors for all models and compounds.
+
+    Returns
+    -------
+    dict[str, dict]
+        Metric names and values for all models.
+    """
+    metrics_dict: dict[str, dict[str, float]] = {}
+    for compound in COMPOUNDS:
+        metrics_dict[f"{compound} barrier error"] = {
+            model: barrier_errors[model][compound] for model in MODELS
+        }
+    return metrics_dict
+
+
+def test_o_diffusion(metrics: dict[str, dict]) -> None:
+    """
+    Run O diffusion test.
+
+    Parameters
+    ----------
+    metrics
+        All O diffusion metrics.
+    """
+    return

--- a/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/analyse_O_diffusion_2D_TMDs.py
+++ b/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/analyse_O_diffusion_2D_TMDs.py
@@ -11,8 +11,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_scatter
 from ml_peg.analysis.utils.utils import load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "nebs" / "O_diffusion_2D_TMDs" / "outputs"
@@ -66,7 +66,7 @@ def plot_nebs(model: str, compound: str) -> None:
         """
         results: dict[str, tuple[list[float], list[float]]] = {}
         structs = read(
-            CALC_PATH / f"O_diffusion_{compound}-{model}-neb-band.extxyz",
+            CALC_PATH / model / f"O_diffusion_{compound}-neb-band.extxyz",
             index=":",
         )
         energies = [struct.get_potential_energy() for struct in structs]
@@ -112,7 +112,7 @@ def barrier_errors() -> dict[str, dict[str, float]]:
         for compound in COMPOUNDS:
             plot_nebs(model_name, compound)
             with open(
-                CALC_PATH / f"O_diffusion_{compound}-{model_name}-neb-results.dat",
+                CALC_PATH / model_name / f"O_diffusion_{compound}-neb-results.dat",
                 encoding="utf8",
             ) as f:
                 data = f.readlines()

--- a/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/analyse_O_diffusion_2D_TMDs.py
+++ b/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/analyse_O_diffusion_2D_TMDs.py
@@ -8,7 +8,7 @@ from ase.io import read, write
 import pytest
 
 from ml_peg.analysis.utils.decorators import build_table, plot_scatter
-from ml_peg.analysis.utils.utils import load_metrics_config
+from ml_peg.analysis.utils.utils import get_struct_info, load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
 from ml_peg.models import current_models
@@ -110,14 +110,17 @@ def barrier_errors() -> dict[str, dict[str, float]]:
 
     for model_name in MODELS:
         for compound in COMPOUNDS:
-            plot_nebs(model_name, compound)
-            with open(
-                CALC_PATH / model_name / f"O_diffusion_{compound}-neb-results.dat",
-                encoding="utf8",
-            ) as f:
-                data = f.readlines()
-                pred_barrier, _, _ = tuple(float(x) for x in data[1].split())
-            results[model_name][compound] = abs(REF_VALUES[compound] - pred_barrier)
+            try:
+                plot_nebs(model_name, compound)
+                with open(
+                    CALC_PATH / model_name / f"O_diffusion_{compound}-neb-results.dat",
+                    encoding="utf8",
+                ) as f:
+                    data = f.readlines()
+                    pred_barrier, _, _ = tuple(float(x) for x in data[1].split())
+                results[model_name][compound] = abs(REF_VALUES[compound] - pred_barrier)
+            except (FileNotFoundError, KeyError):
+                results[model_name][compound] = float("nan")
 
     return results
 
@@ -159,4 +162,10 @@ def test_o_diffusion(metrics: dict[str, dict]) -> None:
     metrics
         All O diffusion metrics.
     """
-    return
+    get_struct_info(
+        calc_path=CALC_PATH,
+        out_path=OUT_PATH,
+        glob_pattern="*-band.extxyz",
+        index=0,
+        write_structs=False,
+    )

--- a/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/metrics.yml
+++ b/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/metrics.yml
@@ -1,0 +1,37 @@
+metrics:
+  MoS2 barrier error:
+    good: 0.05
+    bad: 0.4
+    unit: eV
+    tooltip: "Diffusion barrier error for MoS2"
+    level_of_theory: DFT-PBE
+  MoSe2 barrier error:
+    good: 0.05
+    bad: 0.4
+    unit: eV
+    tooltip: "Diffusion barrier error for MoSe2"
+    level_of_theory: DFT-PBE
+  MoTe2 barrier error:
+    good: 0.05
+    bad: 0.4
+    unit: eV
+    tooltip: "Diffusion barrier error for MoTe2"
+    level_of_theory: DFT-PBE
+  WS2 barrier error:
+    good: 0.05
+    bad: 0.4
+    unit: eV
+    tooltip: "Diffusion barrier error for WS2"
+    level_of_theory: DFT-PBE
+  WSe2 barrier error:
+    good: 0.05
+    bad: 0.4
+    unit: eV
+    tooltip: "Diffusion barrier error for WSe2"
+    level_of_theory: DFT-PBE
+  WTe2 barrier error:
+    good: 0.05
+    bad: 0.4
+    unit: eV
+    tooltip: "Diffusion barrier error for WTe2"
+    level_of_theory: DFT-PBE

--- a/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/metrics.yml
+++ b/ml_peg/analysis/nebs/O_diffusion_2D_TMDs/metrics.yml
@@ -4,34 +4,34 @@ metrics:
     bad: 0.4
     unit: eV
     tooltip: "Diffusion barrier error for MoS2"
-    level_of_theory: DFT-PBE
+    level_of_theory: PBE
   MoSe2 barrier error:
     good: 0.05
     bad: 0.4
     unit: eV
     tooltip: "Diffusion barrier error for MoSe2"
-    level_of_theory: DFT-PBE
+    level_of_theory: PBE
   MoTe2 barrier error:
     good: 0.05
     bad: 0.4
     unit: eV
     tooltip: "Diffusion barrier error for MoTe2"
-    level_of_theory: DFT-PBE
+    level_of_theory: PBE
   WS2 barrier error:
     good: 0.05
     bad: 0.4
     unit: eV
     tooltip: "Diffusion barrier error for WS2"
-    level_of_theory: DFT-PBE
+    level_of_theory: PBE
   WSe2 barrier error:
     good: 0.05
     bad: 0.4
     unit: eV
     tooltip: "Diffusion barrier error for WSe2"
-    level_of_theory: DFT-PBE
+    level_of_theory: PBE
   WTe2 barrier error:
     good: 0.05
     bad: 0.4
     unit: eV
     tooltip: "Diffusion barrier error for WTe2"
-    level_of_theory: DFT-PBE
+    level_of_theory: PBE

--- a/ml_peg/analysis/utils/decorators.py
+++ b/ml_peg/analysis/utils/decorators.py
@@ -495,6 +495,7 @@ def plot_scatter(
     show_line: bool = False,
     show_markers: bool = True,
     hoverdata: dict | None = None,
+    horizontal_lines: list[float | dict[str, Any]] | None = None,
     filename: str = "scatter.json",
     highlight_range: dict = None,
 ) -> Callable:
@@ -515,6 +516,10 @@ def plot_scatter(
         Whether to show markers on the plot. Default is True.
     hoverdata
         Hover data dictionary. Default is `{}`.
+    horizontal_lines
+        Optional horizontal reference lines. Each entry can be either a float ``y``
+        value or a dict with keys ``y`` (required), ``name``, ``color``, ``dash``,
+        and ``width``. Default is ``None``.
     filename
         Filename to save plot as JSON. Default is "scatter.json".
     highlight_range
@@ -559,6 +564,11 @@ def plot_scatter(
                 Results dictionary.
             """
             results = func(*args, **kwargs)
+            dynamic_horizontal_lines: list[float | dict[str, Any]] = []
+            if isinstance(results, dict) and "horizontal_lines" in results:
+                dynamic = results.pop("horizontal_lines")
+                if isinstance(dynamic, list):
+                    dynamic_horizontal_lines = dynamic
 
             hovertemplate = "<b>Pred: </b>%{x}<br>" + "<b>Ref: </b>%{y}<br>"
             customdata = []
@@ -608,6 +618,86 @@ def plot_scatter(
                 xaxis={"title": {"text": x_label}},
                 yaxis={"title": {"text": y_label}},
             )
+
+            all_horizontal_lines = (
+                list(horizontal_lines or []) + dynamic_horizontal_lines
+            )
+            for i, line in enumerate(all_horizontal_lines):
+                if isinstance(line, dict):
+                    if "y" not in line:
+                        continue
+                    y_val = line["y"]
+                    name = line.get("name", "Reference line")
+                    color = line.get("color", "red")
+                    dash = line.get("dash", "dash")
+                    width = line.get("width", 1)
+                else:
+                    y_val = line
+                    name = f"Reference line {i + 1}"
+                    color = "red"
+                    dash = "dash"
+                    width = 1
+
+                fig.add_shape(
+                    type="line",
+                    xref="paper",
+                    yref="y",
+                    x0=0,
+                    x1=1,
+                    y0=y_val,
+                    y1=y_val,
+                    line={"color": color, "width": width, "dash": dash},
+                )
+                # Dummy trace to expose the horizontal line in the legend.
+                fig.add_trace(
+                    go.Scatter(
+                        x=[None],
+                        y=[None],
+                        mode="lines",
+                        name=name,
+                        line={"color": color, "width": width, "dash": dash},
+                        hoverinfo="skip",
+                        showlegend=True,
+                    )
+                )
+
+            # When horizontal reference lines are present, expand y-limits with
+            # padding so an extreme reference line does not sit on the boundary.
+            if all_horizontal_lines:
+
+                def _as_finite_float(v: Any) -> float | None:
+                    try:
+                        out = float(v)
+                    except (TypeError, ValueError):
+                        return None
+                    return out if np.isfinite(out) else None
+
+                y_values = [
+                    y_float
+                    for value in results.values()
+                    if isinstance(value, tuple | list)
+                    and len(value) >= 2
+                    and isinstance(value[1], list | tuple | np.ndarray)
+                    for y in value[1]
+                    for y_float in [_as_finite_float(y)]
+                    if y_float is not None
+                ]
+                y_values.extend(
+                    y_float
+                    for line in all_horizontal_lines
+                    for y_float in [
+                        _as_finite_float(
+                            line.get("y") if isinstance(line, dict) else line
+                        )
+                    ]
+                    if y_float is not None
+                )
+
+                if y_values:
+                    y_min, y_max = min(y_values), max(y_values)
+                    span = y_max - y_min
+                    pad = 0.05 * (span if span > 0 else max(abs(y_min), 1.0))
+                    fig.update_yaxes(range=[y_min - pad, y_max + pad])
 
             fig.update_traces()
 

--- a/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
+++ b/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
@@ -1,0 +1,103 @@
+"""Run O diffusion on 2D TMDs app."""
+
+from __future__ import annotations
+
+from dash import Dash
+from dash.html import Div
+
+from ml_peg.app import APP_ROOT
+from ml_peg.app.base_app import BaseApp
+from ml_peg.app.utils.build_callbacks import (
+    plot_from_table_cell,
+    struct_from_scatter,
+)
+from ml_peg.app.utils.load import read_plot
+from ml_peg.models.get_models import get_model_names
+from ml_peg.models.models import current_models
+
+# Get all models
+MODELS = get_model_names(current_models)
+BENCHMARK_NAME = "O diffusion on 2D TMDs"
+DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/nebs.html#oxygen-adatom-diffusion-on-tmds"
+DATA_PATH = APP_ROOT / "data" / "nebs" / "O_diffusion_2D_TMDs"
+COMPOUNDS = ["MoS2", "MoSe2", "MoTe2", "WS2", "WSe2", "WTe2"]
+
+
+class ODiffusionTMDsApp(BaseApp):
+    """O diffusion on 2D TMDs benchmark app layout and callbacks."""
+
+    def register_callbacks(self) -> None:
+        """Register callbacks to app."""
+        scatter_plots = {
+            model: {
+                f"{compound} barrier error": read_plot(
+                    DATA_PATH / f"figure_{model}_O_diffusion_{compound}.json",
+                    id=f"{BENCHMARK_NAME}-{model}-figure-{compound}",
+                )
+                for compound in COMPOUNDS
+            }
+            for model in MODELS
+        }
+
+        # Assets dir will be parent directory
+        assets_dir = "assets/nebs/O_diffusion_2D_TMDs"
+        structs = {
+            model: {
+                f"{compound} barrier error": (
+                    f"{assets_dir}/{model}/{model}-{compound}-neb-band.extxyz"
+                )
+                for compound in COMPOUNDS
+            }
+            for model in MODELS
+        }
+
+        plot_from_table_cell(
+            table_id=self.table_id,
+            plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
+            cell_to_plot=scatter_plots,
+        )
+
+        for model in MODELS:
+            for compound in COMPOUNDS:
+                struct_from_scatter(
+                    scatter_id=f"{BENCHMARK_NAME}-{model}-figure-{compound}",
+                    struct_id=f"{BENCHMARK_NAME}-struct-placeholder",
+                    structs=structs[model][f"{compound} barrier error"],
+                    mode="traj",
+                )
+
+
+def get_app() -> ODiffusionTMDsApp:
+    """
+    Get O diffusion on 2D TMDs benchmark app layout and callback registration.
+
+    Returns
+    -------
+    ODiffusionTMDsApp
+        Benchmark layout and callback registration.
+    """
+    return ODiffusionTMDsApp(
+        name=BENCHMARK_NAME,
+        description=(
+            "Performance in predicting oxygen adatom diffusion barriers on 2D TMDs."
+        ),
+        docs_url=DOCS_URL,
+        table_path=DATA_PATH / "O_diffusion_metrics_table.json",
+        extra_components=[
+            Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
+            Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
+        ],
+    )
+
+
+if __name__ == "__main__":
+    # Create Dash app
+    full_app = Dash(__name__, assets_folder=DATA_PATH.parent)
+
+    # Construct layout and register callbacks
+    o_diffusion_app = get_app()
+    full_app.layout = o_diffusion_app.layout
+    o_diffusion_app.register_callbacks()
+
+    # Run app
+    full_app.run(port=8056, debug=True)

--- a/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
+++ b/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
+++ b/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
@@ -92,7 +92,7 @@ def get_app() -> ODiffusionTMDsApp:
 
 if __name__ == "__main__":
     # Create Dash app
-    full_app = Dash(__name__, assets_folder=DATA_PATH.parent)
+    full_app = Dash(__name__, assets_folder=DATA_PATH.parent.parent)
 
     # Construct layout and register callbacks
     o_diffusion_app = get_app()

--- a/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
+++ b/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
@@ -40,7 +40,7 @@ class ODiffusionTMDsApp(BaseApp):
         }
 
         # Assets dir will be parent directory
-        assets_dir = "assets/nebs/O_diffusion_2D_TMDs"
+        assets_dir = "/assets/nebs/O_diffusion_2D_TMDs"
         structs = {
             model: {
                 f"{compound} barrier error": (

--- a/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
+++ b/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
@@ -21,6 +21,7 @@ BENCHMARK_NAME = "O diffusion on 2D TMDs"
 DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/nebs.html#oxygen-adatom-diffusion-on-2d-tmds"
 DATA_PATH = APP_ROOT / "data" / "nebs" / "O_diffusion_2D_TMDs"
 COMPOUNDS = ["MoS2", "MoSe2", "MoTe2", "WS2", "WSe2", "WTe2"]
+INFO_PATH = DATA_PATH / "info.json"
 
 
 class ODiffusionTMDsApp(BaseApp):
@@ -87,6 +88,7 @@ def get_app() -> ODiffusionTMDsApp:
             Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
             Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
         ],
+        info_path=INFO_PATH,
     )
 
 

--- a/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
+++ b/ml_peg/app/nebs/O_diffusion_2D_TMDs/app_O_diffusion_2D_TMDs.py
@@ -18,7 +18,7 @@ from ml_peg.models.get_models import get_model_names
 # Get all models
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "O diffusion on 2D TMDs"
-DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/nebs.html#oxygen-adatom-diffusion-on-tmds"
+DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/nebs.html#oxygen-adatom-diffusion-on-2d-tmds"
 DATA_PATH = APP_ROOT / "data" / "nebs" / "O_diffusion_2D_TMDs"
 COMPOUNDS = ["MoS2", "MoSe2", "MoTe2", "WS2", "WSe2", "WTe2"]
 

--- a/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
+++ b/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
@@ -73,15 +73,26 @@ def test_o_diffusion_mos2(relaxed_structs: dict[str, Atoms], model_name: str) ->
     model_name
         Name of model to use.
     """
-    NEB(
-        init_struct=relaxed_structs[f"MoS2_initial.xyz-{model_name}"],
-        final_struct=relaxed_structs[f"MoS2_end.xyz-{model_name}"],
-        n_images=11,
-        interpolator="pymatgen",
-        minimize=True,
-        write_band=True,
-        file_prefix=OUT_PATH / f"O_diffusion_MoS2-{model_name}",
-    ).run()
+    try:
+        NEB(
+            init_struct=relaxed_structs[f"MoS2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"MoS2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="pymatgen",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_MoS2-{model_name}",
+        ).run()
+    except Exception:
+        NEB(
+            init_struct=relaxed_structs[f"MoS2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"MoS2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="ase",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_MoS2-{model_name}",
+        ).run()
 
 
 @pytest.mark.slow
@@ -97,15 +108,26 @@ def test_o_diffusion_mose2(relaxed_structs: dict[str, Atoms], model_name: str) -
     model_name
         Name of model to use.
     """
-    NEB(
-        init_struct=relaxed_structs[f"MoSe2_initial.xyz-{model_name}"],
-        final_struct=relaxed_structs[f"MoSe2_end.xyz-{model_name}"],
-        n_images=11,
-        interpolator="pymatgen",
-        minimize=True,
-        write_band=True,
-        file_prefix=OUT_PATH / f"O_diffusion_MoSe2-{model_name}",
-    ).run()
+    try:
+        NEB(
+            init_struct=relaxed_structs[f"MoSe2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"MoSe2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="pymatgen",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_MoSe2-{model_name}",
+        ).run()
+    except Exception:
+        NEB(
+            init_struct=relaxed_structs[f"MoSe2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"MoSe2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="ase",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_MoSe2-{model_name}",
+        ).run()
 
 
 @pytest.mark.slow
@@ -121,15 +143,26 @@ def test_o_diffusion_mote2(relaxed_structs: dict[str, Atoms], model_name: str) -
     model_name
         Name of model to use.
     """
-    NEB(
-        init_struct=relaxed_structs[f"MoTe2_initial.xyz-{model_name}"],
-        final_struct=relaxed_structs[f"MoTe2_end.xyz-{model_name}"],
-        n_images=11,
-        interpolator="pymatgen",
-        minimize=True,
-        write_band=True,
-        file_prefix=OUT_PATH / f"O_diffusion_MoTe2-{model_name}",
-    ).run()
+    try:
+        NEB(
+            init_struct=relaxed_structs[f"MoTe2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"MoTe2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="pymatgen",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_MoTe2-{model_name}",
+        ).run()
+    except Exception:
+        NEB(
+            init_struct=relaxed_structs[f"MoTe2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"MoTe2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="ase",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_MoTe2-{model_name}",
+        ).run()
 
 
 @pytest.mark.slow
@@ -145,15 +178,26 @@ def test_o_diffusion_ws2(relaxed_structs: dict[str, Atoms], model_name: str) -> 
     model_name
         Name of model to use.
     """
-    NEB(
-        init_struct=relaxed_structs[f"WS2_initial.xyz-{model_name}"],
-        final_struct=relaxed_structs[f"WS2_end.xyz-{model_name}"],
-        n_images=11,
-        interpolator="pymatgen",
-        minimize=True,
-        write_band=True,
-        file_prefix=OUT_PATH / f"O_diffusion_WS2-{model_name}",
-    ).run()
+    try:
+        NEB(
+            init_struct=relaxed_structs[f"WS2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"WS2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="pymatgen",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_WS2-{model_name}",
+        ).run()
+    except Exception:
+        NEB(
+            init_struct=relaxed_structs[f"WS2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"WS2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="ase",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_WS2-{model_name}",
+        ).run()
 
 
 @pytest.mark.slow
@@ -169,15 +213,26 @@ def test_o_diffusion_wse2(relaxed_structs: dict[str, Atoms], model_name: str) ->
     model_name
         Name of model to use.
     """
-    NEB(
-        init_struct=relaxed_structs[f"WSe2_initial.xyz-{model_name}"],
-        final_struct=relaxed_structs[f"WSe2_end.xyz-{model_name}"],
-        n_images=11,
-        interpolator="pymatgen",
-        minimize=True,
-        write_band=True,
-        file_prefix=OUT_PATH / f"O_diffusion_WSe2-{model_name}",
-    ).run()
+    try:
+        NEB(
+            init_struct=relaxed_structs[f"WSe2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"WSe2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="pymatgen",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_WSe2-{model_name}",
+        ).run()
+    except Exception:
+        NEB(
+            init_struct=relaxed_structs[f"WSe2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"WSe2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="ase",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_WSe2-{model_name}",
+        ).run()
 
 
 @pytest.mark.slow
@@ -193,12 +248,23 @@ def test_o_diffusion_wte2(relaxed_structs: dict[str, Atoms], model_name: str) ->
     model_name
         Name of model to use.
     """
-    NEB(
-        init_struct=relaxed_structs[f"WTe2_initial.xyz-{model_name}"],
-        final_struct=relaxed_structs[f"WTe2_end.xyz-{model_name}"],
-        n_images=11,
-        interpolator="pymatgen",
-        minimize=True,
-        write_band=True,
-        file_prefix=OUT_PATH / f"O_diffusion_WTe2-{model_name}",
-    ).run()
+    try:
+        NEB(
+            init_struct=relaxed_structs[f"WTe2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"WTe2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="pymatgen",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_WTe2-{model_name}",
+        ).run()
+    except Exception:
+        NEB(
+            init_struct=relaxed_structs[f"WTe2_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"WTe2_end.xyz-{model_name}"],
+            n_images=11,
+            interpolator="ase",
+            minimize=True,
+            write_band=True,
+            file_prefix=OUT_PATH / f"O_diffusion_WTe2-{model_name}",
+        ).run()

--- a/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
+++ b/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
@@ -6,10 +6,9 @@ from pathlib import Path
 
 from ase import Atoms
 from ase.io import read
-from janus_core.calculations.geom_opt import GeomOpt  # type: ignore
-from janus_core.calculations.neb import NEB  # type: ignore
-import matplotlib.pyplot as plt
-import pytest  # type: ignore
+from janus_core.calculations.geom_opt import GeomOpt
+from janus_core.calculations.neb import NEB
+import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
 from ml_peg.models.get_models import load_models
@@ -80,11 +79,9 @@ def test_o_diffusion_mos2(relaxed_structs: dict[str, Atoms], model_name: str) ->
         n_images=11,
         interpolator="pymatgen",
         minimize=True,
-        plot_band=True,
         write_band=True,
         file_prefix=OUT_PATH / f"O_diffusion_MoS2-{model_name}",
     ).run()
-    plt.close("all")
 
 
 @pytest.mark.slow
@@ -106,11 +103,9 @@ def test_o_diffusion_mose2(relaxed_structs: dict[str, Atoms], model_name: str) -
         n_images=11,
         interpolator="pymatgen",
         minimize=True,
-        plot_band=True,
         write_band=True,
         file_prefix=OUT_PATH / f"O_diffusion_MoSe2-{model_name}",
     ).run()
-    plt.close("all")
 
 
 @pytest.mark.slow
@@ -132,11 +127,9 @@ def test_o_diffusion_mote2(relaxed_structs: dict[str, Atoms], model_name: str) -
         n_images=11,
         interpolator="pymatgen",
         minimize=True,
-        plot_band=True,
         write_band=True,
         file_prefix=OUT_PATH / f"O_diffusion_MoTe2-{model_name}",
     ).run()
-    plt.close("all")
 
 
 @pytest.mark.slow
@@ -158,11 +151,9 @@ def test_o_diffusion_ws2(relaxed_structs: dict[str, Atoms], model_name: str) -> 
         n_images=11,
         interpolator="pymatgen",
         minimize=True,
-        plot_band=True,
         write_band=True,
         file_prefix=OUT_PATH / f"O_diffusion_WS2-{model_name}",
     ).run()
-    plt.close("all")
 
 
 @pytest.mark.slow
@@ -184,11 +175,9 @@ def test_o_diffusion_wse2(relaxed_structs: dict[str, Atoms], model_name: str) ->
         n_images=11,
         interpolator="pymatgen",
         minimize=True,
-        plot_band=True,
         write_band=True,
         file_prefix=OUT_PATH / f"O_diffusion_WSe2-{model_name}",
     ).run()
-    plt.close("all")
 
 
 @pytest.mark.slow
@@ -210,8 +199,6 @@ def test_o_diffusion_wte2(relaxed_structs: dict[str, Atoms], model_name: str) ->
         n_images=11,
         interpolator="pymatgen",
         minimize=True,
-        plot_band=True,
         write_band=True,
         file_prefix=OUT_PATH / f"O_diffusion_WTe2-{model_name}",
     ).run()
-    plt.close("all")

--- a/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
+++ b/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
@@ -1,0 +1,208 @@
+"""Run calculations for oxygen adatom diffusion barriers on 2D TMDs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ase import Atoms
+from ase.io import read
+from janus_core.calculations.geom_opt import GeomOpt  # type: ignore
+from janus_core.calculations.neb import NEB  # type: ignore
+import matplotlib.pyplot as plt
+import pytest  # type: ignore
+
+from ml_peg.models.get_models import load_models
+from ml_peg.models.models import current_models
+
+MODELS = load_models(current_models)
+
+DATA_PATH = Path(__file__).parent / "data"
+OUT_PATH = Path(__file__).parent / "outputs"
+
+COMPOUNDS = ["MoS2", "MoSe2", "MoTe2", "WS2", "WSe2", "WTe2"]
+
+
+@pytest.fixture(scope="module")
+def relaxed_structs() -> dict[str, Atoms]:
+    """
+    Run geometry optimisation on all structures.
+
+    Returns
+    -------
+    dict[str, Atoms]
+        Relaxed structures indexed by structure name and model name.
+    """
+    relaxed_structs = {}
+
+    for model_name, calc in MODELS.items():
+        for compound in COMPOUNDS:
+            for state in ["initial", "end"]:
+                struct_name = f"{compound}_{state}.xyz"
+                struct = read(DATA_PATH / struct_name)
+                struct.calc = calc.get_calculator()
+
+                geomopt = GeomOpt(
+                    struct=struct,
+                    write_results=True,
+                    file_prefix=OUT_PATH / f"{struct_name}-{model_name}",
+                    filter_class=None,
+                )
+                geomopt.run()
+                relaxed_structs[f"{struct_name}-{model_name}"] = geomopt.struct
+    return relaxed_structs
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("model_name", MODELS)
+def test_o_diffusion_mos2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
+    """
+    Run calculations required for oxygen adatom diffusion on MoS2.
+
+    Parameters
+    ----------
+    relaxed_structs
+        Relaxed input structures, indexed by structure name and model name.
+    model_name
+        Name of model to use.
+    """
+    NEB(
+        init_struct=relaxed_structs[f"MoS2_initial.xyz-{model_name}"],
+        final_struct=relaxed_structs[f"MoS2_end.xyz-{model_name}"],
+        n_images=11,
+        interpolator="pymatgen",
+        minimize=True,
+        plot_band=True,
+        write_band=True,
+        file_prefix=OUT_PATH / f"O_diffusion_MoS2-{model_name}",
+    ).run()
+    plt.close("all")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("model_name", MODELS)
+def test_o_diffusion_mose2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
+    """
+    Run calculations required for oxygen adatom diffusion on MoSe2.
+
+    Parameters
+    ----------
+    relaxed_structs
+        Relaxed input structures, indexed by structure name and model name.
+    model_name
+        Name of model to use.
+    """
+    NEB(
+        init_struct=relaxed_structs[f"MoSe2_initial.xyz-{model_name}"],
+        final_struct=relaxed_structs[f"MoSe2_end.xyz-{model_name}"],
+        n_images=11,
+        interpolator="pymatgen",
+        minimize=True,
+        plot_band=True,
+        write_band=True,
+        file_prefix=OUT_PATH / f"O_diffusion_MoSe2-{model_name}",
+    ).run()
+    plt.close("all")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("model_name", MODELS)
+def test_o_diffusion_mote2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
+    """
+    Run calculations required for oxygen adatom diffusion on MoTe2.
+
+    Parameters
+    ----------
+    relaxed_structs
+        Relaxed input structures, indexed by structure name and model name.
+    model_name
+        Name of model to use.
+    """
+    NEB(
+        init_struct=relaxed_structs[f"MoTe2_initial.xyz-{model_name}"],
+        final_struct=relaxed_structs[f"MoTe2_end.xyz-{model_name}"],
+        n_images=11,
+        interpolator="pymatgen",
+        minimize=True,
+        plot_band=True,
+        write_band=True,
+        file_prefix=OUT_PATH / f"O_diffusion_MoTe2-{model_name}",
+    ).run()
+    plt.close("all")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("model_name", MODELS)
+def test_o_diffusion_ws2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
+    """
+    Run calculations required for oxygen adatom diffusion on WS2.
+
+    Parameters
+    ----------
+    relaxed_structs
+        Relaxed input structures, indexed by structure name and model name.
+    model_name
+        Name of model to use.
+    """
+    NEB(
+        init_struct=relaxed_structs[f"WS2_initial.xyz-{model_name}"],
+        final_struct=relaxed_structs[f"WS2_end.xyz-{model_name}"],
+        n_images=11,
+        interpolator="pymatgen",
+        minimize=True,
+        plot_band=True,
+        write_band=True,
+        file_prefix=OUT_PATH / f"O_diffusion_WS2-{model_name}",
+    ).run()
+    plt.close("all")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("model_name", MODELS)
+def test_o_diffusion_wse2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
+    """
+    Run calculations required for oxygen adatom diffusion on WSe2.
+
+    Parameters
+    ----------
+    relaxed_structs
+        Relaxed input structures, indexed by structure name and model name.
+    model_name
+        Name of model to use.
+    """
+    NEB(
+        init_struct=relaxed_structs[f"WSe2_initial.xyz-{model_name}"],
+        final_struct=relaxed_structs[f"WSe2_end.xyz-{model_name}"],
+        n_images=11,
+        interpolator="pymatgen",
+        minimize=True,
+        plot_band=True,
+        write_band=True,
+        file_prefix=OUT_PATH / f"O_diffusion_WSe2-{model_name}",
+    ).run()
+    plt.close("all")
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("model_name", MODELS)
+def test_o_diffusion_wte2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
+    """
+    Run calculations required for oxygen adatom diffusion on WTe2.
+
+    Parameters
+    ----------
+    relaxed_structs
+        Relaxed input structures, indexed by structure name and model name.
+    model_name
+        Name of model to use.
+    """
+    NEB(
+        init_struct=relaxed_structs[f"WTe2_initial.xyz-{model_name}"],
+        final_struct=relaxed_structs[f"WTe2_end.xyz-{model_name}"],
+        n_images=11,
+        interpolator="pymatgen",
+        minimize=True,
+        plot_band=True,
+        write_band=True,
+        file_prefix=OUT_PATH / f"O_diffusion_WTe2-{model_name}",
+    ).run()
+    plt.close("all")

--- a/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
+++ b/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
@@ -11,6 +11,7 @@ from janus_core.calculations.neb import NEB  # type: ignore
 import matplotlib.pyplot as plt
 import pytest  # type: ignore
 
+from ml_peg.calcs.utils.utils import download_s3_data
 from ml_peg.models.get_models import load_models
 from ml_peg.models.models import current_models
 
@@ -34,11 +35,19 @@ def relaxed_structs() -> dict[str, Atoms]:
     """
     relaxed_structs = {}
 
+    structure_dir = (
+        download_s3_data(
+            key="inputs/nebs/O_diffusion_2D_TMDs/O_diffusion_2D_TMDs.zip",
+            filename="O_diffusion_2D_TMDs.zip",
+        )
+        / "O_diffusion_2D_TMDs"
+    )
+
     for model_name, calc in MODELS.items():
         for compound in COMPOUNDS:
             for state in ["initial", "end"]:
                 struct_name = f"{compound}_{state}.xyz"
-                struct = read(DATA_PATH / struct_name)
+                struct = read(structure_dir / struct_name)
                 struct.calc = calc.get_calculator()
 
                 geomopt = GeomOpt(

--- a/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
+++ b/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
@@ -11,8 +11,8 @@ from janus_core.calculations.neb import NEB
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 
@@ -47,14 +47,14 @@ def relaxed_structs() -> dict[str, Atoms]:
             for state in ["initial", "end"]:
                 struct_name = f"{compound}_{state}.xyz"
                 struct = read(structure_dir / struct_name)
-                struct.calc = calc.get_calculator()
+                struct.calc = calc.get_calculator(precision="high")
                 struct.info.setdefault("charge", 0)
                 struct.info.setdefault("spin", 1)
 
                 geomopt = GeomOpt(
                     struct=struct,
                     write_results=True,
-                    file_prefix=OUT_PATH / f"{struct_name}-{model_name}",
+                    file_prefix=OUT_PATH / model_name / struct_name,
                     filter_class=None,
                 )
                 geomopt.run()
@@ -63,10 +63,13 @@ def relaxed_structs() -> dict[str, Atoms]:
 
 
 @pytest.mark.slow
+@pytest.mark.parametrize("compound", COMPOUNDS)
 @pytest.mark.parametrize("model_name", MODELS)
-def test_o_diffusion_mos2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
+def test_o_diffusion(
+    relaxed_structs: dict[str, Atoms], model_name: str, compound: str
+) -> None:
     """
-    Run calculations required for oxygen adatom diffusion on MoS2.
+    Run calculations required for oxygen adatom diffusion on a TMD compound.
 
     Parameters
     ----------
@@ -74,199 +77,26 @@ def test_o_diffusion_mos2(relaxed_structs: dict[str, Atoms], model_name: str) ->
         Relaxed input structures, indexed by structure name and model name.
     model_name
         Name of model to use.
+    compound
+        Name of compound to use.
     """
     try:
         NEB(
-            init_struct=relaxed_structs[f"MoS2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"MoS2_end.xyz-{model_name}"],
+            init_struct=relaxed_structs[f"{compound}_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"{compound}_end.xyz-{model_name}"],
             n_images=11,
             interpolator="pymatgen",
             minimize=True,
             write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_MoS2-{model_name}",
+            file_prefix=OUT_PATH / model_name / f"O_diffusion_{compound}",
         ).run()
     except Exception:
         NEB(
-            init_struct=relaxed_structs[f"MoS2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"MoS2_end.xyz-{model_name}"],
+            init_struct=relaxed_structs[f"{compound}_initial.xyz-{model_name}"],
+            final_struct=relaxed_structs[f"{compound}_end.xyz-{model_name}"],
             n_images=11,
             interpolator="ase",
             minimize=True,
             write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_MoS2-{model_name}",
-        ).run()
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("model_name", MODELS)
-def test_o_diffusion_mose2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
-    """
-    Run calculations required for oxygen adatom diffusion on MoSe2.
-
-    Parameters
-    ----------
-    relaxed_structs
-        Relaxed input structures, indexed by structure name and model name.
-    model_name
-        Name of model to use.
-    """
-    try:
-        NEB(
-            init_struct=relaxed_structs[f"MoSe2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"MoSe2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="pymatgen",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_MoSe2-{model_name}",
-        ).run()
-    except Exception:
-        NEB(
-            init_struct=relaxed_structs[f"MoSe2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"MoSe2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="ase",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_MoSe2-{model_name}",
-        ).run()
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("model_name", MODELS)
-def test_o_diffusion_mote2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
-    """
-    Run calculations required for oxygen adatom diffusion on MoTe2.
-
-    Parameters
-    ----------
-    relaxed_structs
-        Relaxed input structures, indexed by structure name and model name.
-    model_name
-        Name of model to use.
-    """
-    try:
-        NEB(
-            init_struct=relaxed_structs[f"MoTe2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"MoTe2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="pymatgen",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_MoTe2-{model_name}",
-        ).run()
-    except Exception:
-        NEB(
-            init_struct=relaxed_structs[f"MoTe2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"MoTe2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="ase",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_MoTe2-{model_name}",
-        ).run()
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("model_name", MODELS)
-def test_o_diffusion_ws2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
-    """
-    Run calculations required for oxygen adatom diffusion on WS2.
-
-    Parameters
-    ----------
-    relaxed_structs
-        Relaxed input structures, indexed by structure name and model name.
-    model_name
-        Name of model to use.
-    """
-    try:
-        NEB(
-            init_struct=relaxed_structs[f"WS2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"WS2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="pymatgen",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_WS2-{model_name}",
-        ).run()
-    except Exception:
-        NEB(
-            init_struct=relaxed_structs[f"WS2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"WS2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="ase",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_WS2-{model_name}",
-        ).run()
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("model_name", MODELS)
-def test_o_diffusion_wse2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
-    """
-    Run calculations required for oxygen adatom diffusion on WSe2.
-
-    Parameters
-    ----------
-    relaxed_structs
-        Relaxed input structures, indexed by structure name and model name.
-    model_name
-        Name of model to use.
-    """
-    try:
-        NEB(
-            init_struct=relaxed_structs[f"WSe2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"WSe2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="pymatgen",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_WSe2-{model_name}",
-        ).run()
-    except Exception:
-        NEB(
-            init_struct=relaxed_structs[f"WSe2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"WSe2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="ase",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_WSe2-{model_name}",
-        ).run()
-
-
-@pytest.mark.slow
-@pytest.mark.parametrize("model_name", MODELS)
-def test_o_diffusion_wte2(relaxed_structs: dict[str, Atoms], model_name: str) -> None:
-    """
-    Run calculations required for oxygen adatom diffusion on WTe2.
-
-    Parameters
-    ----------
-    relaxed_structs
-        Relaxed input structures, indexed by structure name and model name.
-    model_name
-        Name of model to use.
-    """
-    try:
-        NEB(
-            init_struct=relaxed_structs[f"WTe2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"WTe2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="pymatgen",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_WTe2-{model_name}",
-        ).run()
-    except Exception:
-        NEB(
-            init_struct=relaxed_structs[f"WTe2_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"WTe2_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="ase",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / f"O_diffusion_WTe2-{model_name}",
+            file_prefix=OUT_PATH / model_name / f"O_diffusion_{compound}",
         ).run()

--- a/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
+++ b/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
@@ -48,6 +48,8 @@ def relaxed_structs() -> dict[str, Atoms]:
                 struct_name = f"{compound}_{state}.xyz"
                 struct = read(structure_dir / struct_name)
                 struct.calc = calc.get_calculator()
+                struct.info.setdefault("charge", 0)
+                struct.info.setdefault("spin", 1)
 
                 geomopt = GeomOpt(
                     struct=struct,

--- a/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
+++ b/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from pathlib import Path
+from warnings import warn
 
 from ase import Atoms
-from ase.io import read
+from ase.io import read, write
 from janus_core.calculations.geom_opt import GeomOpt
 from janus_core.calculations.neb import NEB
+import numpy as np
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
@@ -57,7 +59,14 @@ def relaxed_structs() -> dict[str, Atoms]:
                     file_prefix=OUT_PATH / model_name / struct_name,
                     filter_class=None,
                 )
-                geomopt.run()
+                try:
+                    geomopt.run()
+                except Exception as exc:
+                    warn(
+                        f"Error for {struct_name} with {model_name}: {exc}",
+                        stacklevel=2,
+                    )
+                    struct.info["energy"] = np.nan
                 relaxed_structs[f"{struct_name}-{model_name}"] = geomopt.struct
     return relaxed_structs
 
@@ -80,10 +89,12 @@ def test_o_diffusion(
     compound
         Name of compound to use.
     """
+    init_struct = relaxed_structs[f"{compound}_initial.xyz-{model_name}"]
+    final_struct = relaxed_structs[f"{compound}_end.xyz-{model_name}"]
     try:
         NEB(
-            init_struct=relaxed_structs[f"{compound}_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"{compound}_end.xyz-{model_name}"],
+            init_struct=init_struct,
+            final_struct=final_struct,
             n_images=11,
             interpolator="pymatgen",
             minimize=True,
@@ -91,12 +102,28 @@ def test_o_diffusion(
             file_prefix=OUT_PATH / model_name / f"O_diffusion_{compound}",
         ).run()
     except Exception:
-        NEB(
-            init_struct=relaxed_structs[f"{compound}_initial.xyz-{model_name}"],
-            final_struct=relaxed_structs[f"{compound}_end.xyz-{model_name}"],
-            n_images=11,
-            interpolator="ase",
-            minimize=True,
-            write_band=True,
-            file_prefix=OUT_PATH / model_name / f"O_diffusion_{compound}",
-        ).run()
+        try:
+            NEB(
+                init_struct=init_struct,
+                final_struct=final_struct,
+                n_images=11,
+                interpolator="ase",
+                minimize=True,
+                write_band=True,
+                file_prefix=OUT_PATH / model_name / f"O_diffusion_{compound}",
+            ).run()
+        except Exception as e:
+            warn(f"Error running NEB for {model_name}: {e}", stacklevel=2)
+            out_dir = OUT_PATH / model_name
+            out_dir.mkdir(exist_ok=True, parents=True)
+            write(
+                out_dir / f"O_diffusion_{compound}-neb-band.extxyz",
+                [init_struct, final_struct],
+            )
+            with open(
+                out_dir / f"O_diffusion_{compound}-neb-results.dat",
+                "w",
+                encoding="utf8",
+            ) as out:
+                print("#Barrier [eV] | delta E [eV] | Max force [eV/Å] ", file=out)
+                print(np.nan, np.nan, np.nan, file=out)

--- a/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
+++ b/ml_peg/calcs/nebs/O_diffusion_2D_TMDs/calc_O_diffusion_2D_TMDs.py
@@ -58,6 +58,7 @@ def relaxed_structs() -> dict[str, Atoms]:
                     write_results=True,
                     file_prefix=OUT_PATH / model_name / struct_name,
                     filter_class=None,
+                    steps=100,
                 )
                 try:
                     geomopt.run()

--- a/ml_peg/calcs/nebs/li_diffusion/calc_li_diffusion.py
+++ b/ml_peg/calcs/nebs/li_diffusion/calc_li_diffusion.py
@@ -96,7 +96,7 @@ def test_li_diffusion_b(relaxed_structs: dict[str, Atoms], model_name: str) -> N
             image.info.setdefault("spin", 1)
         neb.run()
     except Exception as e:
-        print(f"Error running NEB for {model_name} path B: {e}")
+        warn(f"Error running NEB for {model_name} path B: {e}", stacklevel=2)
         # Write out equivalent data
         out_dir = OUT_PATH / model_name
         out_dir.mkdir(exist_ok=True, parents=True)
@@ -143,7 +143,7 @@ def test_li_diffusion_c(relaxed_structs: dict[str, Atoms], model_name: str) -> N
             image.info.setdefault("spin", 1)
         neb.run()
     except Exception as e:
-        print(f"Error running NEB for {model_name} path C: {e}")
+        warn(f"Error running NEB for {model_name} path C: {e}", stacklevel=2)
         # Write out equivalent data
         out_dir = OUT_PATH / model_name
         out_dir.mkdir(exist_ok=True, parents=True)

--- a/ml_peg/models/models.yml
+++ b/ml_peg/models/models.yml
@@ -1,11 +1,12 @@
-mace-mp-0a:
-  module: mace.calculators
-  class_name: mace_mp
-  device: "auto"
-  trained_on_dispersion: false
-  level_of_theory: PBE
-  kwargs:
-    model: "medium"
+# mace-mp-0a:
+#   module: mace.calculators
+#   class_name: mace_mp
+#   device: "auto"
+#   default_dtype: float32
+#   trained_on_d3: false
+#   level_of_theory: PBE
+#   kwargs:
+#     model: "medium"
 
 mace-mp-0b3:
   module: mace.calculators
@@ -16,36 +17,38 @@ mace-mp-0b3:
   kwargs:
     model: "medium-0b3"
 
-mace-mpa-0:
-  module: mace.calculators
-  class_name: mace_mp
-  device: "auto"
-  trained_on_dispersion: false
-  level_of_theory: PBE
-  kwargs:
-    model: "medium-mpa-0"
+# mace-mpa-0:
+#   module: mace.calculators
+#   class_name: mace_mp
+#   device: "auto"
+#   default_dtype: float32
+#   trained_on_d3: false
+#   level_of_theory: PBE
+#   kwargs:
+#     model: "medium-mpa-0"
 
-mace-omat-0:
-  module: mace.calculators
-  class_name: mace_mp
-  device: "auto"
-  trained_on_dispersion: false
-  level_of_theory: PBE
-  kwargs:
-    model: "medium-omat-0"
+# mace-omat-0:
+#   module: mace.calculators
+#   class_name: mace_mp
+#   device: "auto"
+#   default_dtype: float32
+#   trained_on_d3: false
+#   level_of_theory: PBE
+#   kwargs:
+#     model: "medium-omat-0"
 
-mace-matpes-r2scan:
-  module: mace.calculators
-  class_name: mace_mp
-  device: "auto"
-  trained_on_dispersion: false
-  level_of_theory: r2SCAN
-  kwargs:
-    model: "mace-matpes-r2scan-0"
-    head: "matpes_pbe"
-  dispersion_kwargs:
-    xc: r2scan
-    label: D4
+# mace-matpes-r2scan:
+#   module: mace.calculators
+#   class_name: mace_mp
+#   device: "auto"
+#   default_dtype: float32
+#   trained_on_d3: false
+#   level_of_theory: r2SCAN
+#   kwargs:
+#     model: "mace-matpes-r2scan-0"
+#     head: "matpes_pbe"
+#   d3_kwargs:
+#     xc: r2scan
 
 # mace-mh-1-omat:
 #   module: mace.calculators
@@ -60,8 +63,9 @@ mace-matpes-r2scan:
 orb-v3-consv-inf-omat:
   module: orb_models.inference.calculator
   class_name: OrbCalc
-  device: "cpu"
-  trained_on_dispersion: false
+  device: "cuda"
+  default_dtype: float32-high
+  trained_on_d3: false
   level_of_theory: PBE
   kwargs:
     name: "orb_v3_conservative_inf_omat"
@@ -187,40 +191,14 @@ orb-v3-consv-omol:
 #     model_name: "uma-m-1p1"
 #     task_name: "omol"
 
-pet-mad:
-  module: pet_mad.calculator
-  class_name: PETMADCalculator
-  device: "cpu"
-  trained_on_dispersion: false
-  level_of_theory: PBEsol
-  kwargs:
-    version: "v1.0.2"
-  dispersion_kwargs:
-    xc: pbesol
-
-# mace-polar-1-s:
-#   module: mace.calculators
-#   class_name: mace_polar
+# pet-mad:
+#   module: pet_mad.calculator
+#   class_name: PETMADCalculator
 #   device: "cpu"
-#   trained_on_dispersion: true
-#   level_of_theory: ωB97M-V
+#   default_dtype: float32
+#   trained_on_d3: false
+#   level_of_theory: PBEsol
 #   kwargs:
-#     model: "polar-1-s"
-
-# mace-polar-1-m:
-#   module: mace.calculators
-#   class_name: mace_polar
-#   device: "cpu"
-#   trained_on_dispersion: true
-#   level_of_theory: ωB97M-V
-#   kwargs:
-#     model: "polar-1-m"
-
-# mace-polar-1-l:
-#   module: mace.calculators
-#   class_name: mace_polar
-#   device: "cpu"
-#   trained_on_dispersion: true
-#   level_of_theory: ωB97M-V
-#   kwargs:
-#     model: "polar-1-l"
+#     version: "v1.0.2"
+#   d3_kwargs:
+#     xc: pbesol

--- a/ml_peg/models/models.yml
+++ b/ml_peg/models/models.yml
@@ -1,12 +1,11 @@
-# mace-mp-0a:
-#   module: mace.calculators
-#   class_name: mace_mp
-#   device: "auto"
-#   default_dtype: float32
-#   trained_on_d3: false
-#   level_of_theory: PBE
-#   kwargs:
-#     model: "medium"
+mace-mp-0a:
+  module: mace.calculators
+  class_name: mace_mp
+  device: "auto"
+  trained_on_dispersion: false
+  level_of_theory: PBE
+  kwargs:
+    model: "medium"
 
 mace-mp-0b3:
   module: mace.calculators
@@ -17,38 +16,36 @@ mace-mp-0b3:
   kwargs:
     model: "medium-0b3"
 
-# mace-mpa-0:
-#   module: mace.calculators
-#   class_name: mace_mp
-#   device: "auto"
-#   default_dtype: float32
-#   trained_on_d3: false
-#   level_of_theory: PBE
-#   kwargs:
-#     model: "medium-mpa-0"
+mace-mpa-0:
+  module: mace.calculators
+  class_name: mace_mp
+  device: "auto"
+  trained_on_dispersion: false
+  level_of_theory: PBE
+  kwargs:
+    model: "medium-mpa-0"
 
-# mace-omat-0:
-#   module: mace.calculators
-#   class_name: mace_mp
-#   device: "auto"
-#   default_dtype: float32
-#   trained_on_d3: false
-#   level_of_theory: PBE
-#   kwargs:
-#     model: "medium-omat-0"
+mace-omat-0:
+  module: mace.calculators
+  class_name: mace_mp
+  device: "auto"
+  trained_on_dispersion: false
+  level_of_theory: PBE
+  kwargs:
+    model: "medium-omat-0"
 
-# mace-matpes-r2scan:
-#   module: mace.calculators
-#   class_name: mace_mp
-#   device: "auto"
-#   default_dtype: float32
-#   trained_on_d3: false
-#   level_of_theory: r2SCAN
-#   kwargs:
-#     model: "mace-matpes-r2scan-0"
-#     head: "matpes_pbe"
-#   d3_kwargs:
-#     xc: r2scan
+mace-matpes-r2scan:
+  module: mace.calculators
+  class_name: mace_mp
+  device: "auto"
+  trained_on_dispersion: false
+  level_of_theory: r2SCAN
+  kwargs:
+    model: "mace-matpes-r2scan-0"
+    head: "matpes_pbe"
+  dispersion_kwargs:
+    xc: r2scan
+    label: D4
 
 # mace-mh-1-omat:
 #   module: mace.calculators
@@ -63,9 +60,8 @@ mace-mp-0b3:
 orb-v3-consv-inf-omat:
   module: orb_models.inference.calculator
   class_name: OrbCalc
-  device: "cuda"
-  default_dtype: float32-high
-  trained_on_d3: false
+  device: "cpu"
+  trained_on_dispersion: false
   level_of_theory: PBE
   kwargs:
     name: "orb_v3_conservative_inf_omat"
@@ -191,14 +187,40 @@ orb-v3-consv-omol:
 #     model_name: "uma-m-1p1"
 #     task_name: "omol"
 
-# pet-mad:
-#   module: pet_mad.calculator
-#   class_name: PETMADCalculator
+pet-mad:
+  module: pet_mad.calculator
+  class_name: PETMADCalculator
+  device: "cpu"
+  trained_on_dispersion: false
+  level_of_theory: PBEsol
+  kwargs:
+    version: "v1.0.2"
+  dispersion_kwargs:
+    xc: pbesol
+
+# mace-polar-1-s:
+#   module: mace.calculators
+#   class_name: mace_polar
 #   device: "cpu"
-#   default_dtype: float32
-#   trained_on_d3: false
-#   level_of_theory: PBEsol
+#   trained_on_dispersion: true
+#   level_of_theory: ωB97M-V
 #   kwargs:
-#     version: "v1.0.2"
-#   d3_kwargs:
-#     xc: pbesol
+#     model: "polar-1-s"
+
+# mace-polar-1-m:
+#   module: mace.calculators
+#   class_name: mace_polar
+#   device: "cpu"
+#   trained_on_dispersion: true
+#   level_of_theory: ωB97M-V
+#   kwargs:
+#     model: "polar-1-m"
+
+# mace-polar-1-l:
+#   module: mace.calculators
+#   class_name: mace_polar
+#   device: "cpu"
+#   trained_on_dispersion: true
+#   level_of_theory: ωB97M-V
+#   kwargs:
+#     model: "polar-1-l"


### PR DESCRIPTION
## Pre-review checklist for PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Adds a new NEB benchmark for oxygen adatom diffusion on 2D TMDs (MoS2, MoSe2, MoTe2, WS2, WSe2, WTe2).  
Includes calculation workflows, analysis metrics/tables, and the Dash app entry, plus user guide documentation and model registry updates.

## Linked issue

Resolves #303

## Progress

- [x] Calculations
- [x] Analysis
- [x] Application
- [x] Documentation

## Testing

Tested on CUDA with: `mace-mp-0b3`, `orb-v3-consv-inf-omat`, `uma-s-1p1-omat`

## New decorators/callbacks

None.
