### PR TITLE
Deselect active cell and make tables non-editable

### DIFF
--- a/ml_peg/app/build_app.py
+++ b/ml_peg/app/build_app.py
@@ -303,6 +303,7 @@ def build_summary_table(
         persistence_type="session",
         persisted_props=["data"],
         tooltip_header=tooltip_header,
+        editable=False,
     )
     table.column_widths = column_widths
     table.description = description

--- a/ml_peg/app/utils/build_callbacks.py
+++ b/ml_peg/app/utils/build_callbacks.py
@@ -42,7 +42,11 @@ def plot_from_table_column(
         Dictionary relating table headers (keys) and plot to show (values).
     """
 
-    @callback(Output(plot_id, "children"), Input(table_id, "active_cell"))
+    @callback(
+        Output(plot_id, "children"),
+        Output(table_id, "active_cell"),
+        Input(table_id, "active_cell"),
+    )
     def show_plot(active_cell) -> Div:
         """
         Register callback to show plot when a table column is clicked.
@@ -58,11 +62,11 @@ def plot_from_table_column(
             Message explaining interactivity, or plot on table click.
         """
         if not active_cell:
-            return Div("Click on a metric to view plot.")
+            return Div("Click on a metric to view plot."), None
         column_id = active_cell.get("column_id", None)
         if column_id:
             if column_id in column_to_plot:
-                return Div(column_to_plot[column_id])
+                return Div(column_to_plot[column_id]), None
             raise PreventUpdate
         raise ValueError("Invalid column_id")
 
@@ -91,6 +95,7 @@ def plot_from_table_cell(
 
     @callback(
         Output(plot_id, "children"),
+        Output(table_id, "active_cell"),
         Input(table_id, "active_cell"),
         Input(table_id, "data"),
     )
@@ -111,7 +116,7 @@ def plot_from_table_cell(
             Message explaining interactivity, or plot on cell click.
         """
         if not active_cell:
-            return Div("Click on a metric to view plot.")
+            return Div("Click on a metric to view plot."), None
         column_id = active_cell.get("column_id", None)
         row_id = active_cell.get("row_id", None)
         row_index = active_cell.get("row", None)
@@ -121,13 +126,13 @@ def plot_from_table_cell(
             try:
                 cell_value = current_table_data[row_index].get(column_id)
                 if cell_value is None:
-                    return Div("No data available for this model.")
+                    return Div("No data available for this model."), None
             except (IndexError, KeyError, TypeError):
                 pass  # Fall through to normal handling
 
         if row_id in cell_to_plot and column_id in cell_to_plot[row_id]:
-            return Div(cell_to_plot[row_id][column_id])
-        return Div("Click on a metric to view plot.")
+            return Div(cell_to_plot[row_id][column_id]), None
+        return Div("Click on a metric to view plot."), None
 
 
 def struct_from_scatter(
@@ -219,6 +224,7 @@ def struct_from_table(
 
     @callback(
         Output(struct_id, "children", allow_duplicate=True),
+        Output(table_id, "active_cell"),
         Input(table_id, "active_cell"),
         prevent_initial_call="initial_duplicate",
     )
@@ -237,7 +243,7 @@ def struct_from_table(
             Visualised structure on plot click.
         """
         if not active_cell:
-            return Div("Click on a metric to view the structure.")
+            return Div("Click on a metric to view the structure."), None
 
         column_id = active_cell.get("column_id", None)
         if column_id:
@@ -254,7 +260,7 @@ def struct_from_table(
                             "borderRadius": "5px",
                         },
                     )
-                )
+                ), None
 
             raise PreventUpdate
         raise ValueError("Invalid column_id")
@@ -644,6 +650,7 @@ def scatter_and_assets_from_table(
         Output(plot_container_id, "children"),
         Output(scatter_metadata_store_id, "data"),
         Output(last_cell_store_id, "data"),
+        Output(table_id, "active_cell"),
         Input(table_id, "active_cell"),
         State(last_cell_store_id, "data"),
         prevent_initial_call=True,
@@ -705,7 +712,7 @@ def scatter_and_assets_from_table(
             raise PreventUpdate
         content, metadata = result
 
-        return content, metadata, active_cell
+        return content, metadata, active_cell, None
 
 
 def model_asset_from_scatter(

--- a/ml_peg/app/utils/load.py
+++ b/ml_peg/app/utils/load.py
@@ -182,7 +182,7 @@ def rebuild_table(
         tooltip_header=tooltip_header,
         tooltip_delay=100,
         tooltip_duration=None,
-        editable=True,
+        editable=False,
         id=id,
         style_data_conditional=style_with_warnings,
         style_cell_conditional=style_cell_conditional,


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Converts Dash `DataTable`s to non-editable, and deselects cells after click. This simplifies callback complexity, and prevents 'multiple clicks' when selecting table cells to view plots etc, which seems to be more likely as the complexity of tables increases.

## Testing

Tested locally and I couldn't see any impacts, although I'm also not sure if there was a reason to originally allow cells to be editable.
