### PR TITLE
Fix default weights for summary tables

### DIFF
--- a/ml_peg/app/base_app.py
+++ b/ml_peg/app/base_app.py
@@ -82,7 +82,6 @@ class BaseApp(ABC):
             docs_url=self.docs_url,
             table=self.table,
             thresholds=getattr(self.table, "thresholds", None),
-            weights=getattr(self.table, "weights", None),
             extra_components=self.extra_components,
         )
 

--- a/ml_peg/app/build_app.py
+++ b/ml_peg/app/build_app.py
@@ -145,19 +145,19 @@ def build_category(
             all_tables[category],
             table_id=f"{category_title}-summary-table",
             description=category_descrip,
+            weights={f"{key} Score": value for key, value in benchmark_weights.items()},
         )
-        category_tables[category_title] = summary_table
+
+        # Store category weight for overall summary
         category_weights[f"{category_title} Score"] = category_weight
-        benchmark_weights = {
-            f"{key} Score": value for key, value in benchmark_weights.items()
-        }
+
+        category_tables[category_title] = summary_table
 
         # Build weight components for category summary table
         weight_components = build_weight_components(
             header="Benchmark weights",
             table=summary_table,
             column_widths=getattr(summary_table, "column_widths", None),
-            weights=benchmark_weights,
         )
 
         # Build full layout with summary table, weight controls, and test layouts
@@ -205,6 +205,7 @@ def build_summary_table(
     tables: dict[str, DataTable],
     table_id: str = "summary-table",
     description: str | None = None,
+    weights: dict[str, float] | None = None,
 ) -> DataTable:
     """
     Build summary table from a set of tables.
@@ -217,6 +218,8 @@ def build_summary_table(
         ID of table being built. Default is 'summary-table'.
     description
         Description of summary table. Default is None.
+    weights
+        Weights for each column. Default is `None`, which sets all weights to 1.
 
     Returns
     -------
@@ -344,6 +347,7 @@ def build_summary_table(
     table.model_levels_of_theory = model_levels
     table.metric_levels_of_theory = {}
     table.model_configs = model_configs
+    table.weights = weights
     return table
 
 
@@ -441,12 +445,11 @@ def build_full_app(full_app: Dash, category: str = "*") -> None:
     # Combine tests into categories and create category summary
     cat_layouts, cat_tables, cat_weights = build_category(all_layouts, all_tables)
     # Build overall summary table
-    summary_table = build_summary_table(cat_tables)
+    summary_table = build_summary_table(cat_tables, weights=cat_weights)
     weight_components = build_weight_components(
         header="Category weights",
         table=summary_table,
-        column_widths=getattr(summary_table, "column_widths", None),
-        weights=cat_weights,
+        column_widths=summary_table.column_widths,
     )
     # Build summary and category tabs
     build_tabs(full_app, cat_layouts, summary_table, weight_components)

--- a/ml_peg/app/utils/build_components.py
+++ b/ml_peg/app/utils/build_components.py
@@ -132,7 +132,6 @@ def build_weight_input(
 def build_weight_components(
     header: str,
     table: DataTable,
-    weights: dict[str, float] | None = None,
     *,
     use_thresholds: bool = False,
     column_widths: dict[str, int] | None = None,
@@ -147,9 +146,6 @@ def build_weight_components(
         Header for above sliders.
     table
         DataTable to build weight components for.
-    weights
-        Optional weights for each metric, usually set during analysis. Default is
-        `None`, which sets all weights to 1.
     use_thresholds
         Whether this table also exposes normalization thresholds. When True,
         weight callbacks will reuse the raw-data store and normalization store to
@@ -179,7 +175,7 @@ def build_weight_components(
     input_ids = [f"{table.id}-{col}" for col in columns]
 
     # Set default weights
-    weights = weights if weights else {}
+    weights = table.weights if table.weights else {}
     for column in columns:
         weights.setdefault(column, 1.0)
 
@@ -524,7 +520,6 @@ def build_test_layout(
     docs_url: str | None = None,
     column_widths: dict[str, int] | None = None,
     thresholds: Thresholds | None = None,
-    weights: dict[str, float] | None = None,
 ) -> Div:
     """
     Build app layout for a test.
@@ -536,7 +531,8 @@ def build_test_layout(
     description
         Description of test.
     table
-        Dash Table with metric results.
+        Dash Table with metric results. Can include a `weights` attribute to be used by
+        `build_weight_components`.
     extra_components
         List of Dash Components to include after the metrics table.
     docs_url
@@ -548,9 +544,6 @@ def build_test_layout(
         Optional normalization metadata (metric -> (good, bad, unit)) supplied via the
         analysis pipeline. When provided, inline threshold controls are rendered
         automatically.
-    weights
-        Optional weights for each metric, usually set during analysis. Default is
-        `None`, which sets all weights to 1.
 
     Returns
     -------
@@ -628,7 +621,6 @@ def build_test_layout(
     metric_weights = build_weight_components(
         header="Metric Weights",
         table=table,
-        weights=weights,
         use_thresholds=True,
         column_widths=column_widths,
         thresholds=thresholds,


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Fix resetting default weights for summary tables.

These are set via `table.weights`, as when building the weight components we pass `default_weights=getattr(table, "weights", None)` to the callbacks.

This was being set for the benchmark tables, as we add this attribute on loading, but not the summary tables, leading to resetting the weights reverting everything to 1 for the summary tables.