### PR TITLE
New benchmark: Elemental Transition Metals Vacancy Formation Energies

### DIFF
--- a/docs/source/user_guide/benchmarks/bulk_crystal.rst
+++ b/docs/source/user_guide/benchmarks/bulk_crystal.rst
@@ -115,3 +115,43 @@ Reference data:
 
 * Same as input data
 * PBE
+
+
+Elemental TM Vacancy Formation Energies
+=======================================
+
+Summary
+-------
+
+Performance in predicting vacancy formation energies for 42 fcc or hcp elemental transition metal structures.
+
+Metrics
+-------
+
+1. MAE
+
+Mean absolute error (MAE) between predicted and reference (PBE) vacancy formation energies values.
+
+For each elemental transition metal structure, the vacancy formation enthalpy is determined by evaluating the total energy of the cell containing the monovacancy and evaluating the total energy of the undefected cell and comparing these. Note: the undefected cell energy is scaled by a fraction in order to conserve the appropriate number of atoms.
+
+From the reference paper providing the structures, the elemental transition metals are a subset. Note:
+    * For magnetic structures, the reference spin-polarized calculations only is used.
+    * Unstable element-structure combinations are not included.
+
+Computational cost
+------------------
+
+Low: tests are likely to take a couple of minutes to run on CPU.
+
+
+Data availability
+-----------------
+
+Input structures:
+
+* T. Angsten et al. Elemental vacancy diffusion database from high-throughput first-principles calculations for fcc and hcp structures. New J. Phys. 2024 16 015018
+
+Reference data:
+
+* Same as input data
+* PBE

--- a/docs/source/user_guide/benchmarks/bulk_crystal.rst
+++ b/docs/source/user_guide/benchmarks/bulk_crystal.rst
@@ -169,11 +169,11 @@ Metrics
 
 Computational cost
 ------------------
+
 Low. Every eos curve requires 50 calls on unit cells.
 
 Data availability
 -----------------
-
 
 Input structures:
 
@@ -579,3 +579,43 @@ Reference data:
 
 * DFT (PBE) force constants, thermal properties and relaxed structures from the Alexandria
   phonon benchmark database.
+
+
+Elemental TM Vacancy Formation Energies
+=======================================
+
+Summary
+-------
+
+Performance in predicting vacancy formation energies for 42 fcc or hcp elemental transition metal structures.
+
+Metrics
+-------
+
+1. MAE
+
+Mean absolute error (MAE) between predicted and reference (PBE) vacancy formation energies values.
+
+For each elemental transition metal structure, the vacancy formation enthalpy is determined by evaluating the total energy of the cell containing the monovacancy and evaluating the total energy of the undefected cell and comparing these. Note: the undefected cell energy is scaled by a fraction in order to conserve the appropriate number of atoms.
+
+From the reference paper providing the structures, the elemental transition metals are a subset. Note:
+    * For magnetic structures, the reference spin-polarized calculations only is used.
+    * Unstable element-structure combinations are not included.
+
+Computational cost
+------------------
+
+Low: tests are likely to take a couple of minutes to run on CPU.
+
+
+Data availability
+-----------------
+
+Input structures:
+
+* T. Angsten et al. Elemental vacancy diffusion database from high-throughput first-principles calculations for fcc and hcp structures. New J. Phys. 2024 16 015018
+
+Reference data:
+
+* Same as input data
+* PBE

--- a/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/analyse_elemental_tm_vacancies.py
+++ b/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/analyse_elemental_tm_vacancies.py
@@ -1,0 +1,169 @@
+"""Analyse Elemental TM Vacancy Formation Energies benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ase.io import read, write
+import pytest
+
+from ml_peg.analysis.utils.decorators import build_table, plot_parity
+from ml_peg.analysis.utils.utils import load_metrics_config, mae
+from ml_peg.app import APP_ROOT
+from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models.get_models import get_model_names
+from ml_peg.models.models import current_models
+
+MODELS = get_model_names(current_models)
+CALC_PATH = CALCS_ROOT / "bulk_crystal" / "elemental_tm_vacancies" / "outputs"
+OUT_PATH = APP_ROOT / "data" / "bulk_crystal" / "elemental_tm_vacancies"
+
+METRICS_CONFIG_PATH = Path(__file__).with_name("metrics.yml")
+DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
+    METRICS_CONFIG_PATH
+)
+
+
+def get_system_names() -> list[str]:
+    """
+    Get list of all system names.
+
+    Returns
+    -------
+    list[str]
+        List of system names from structure files.
+    """
+    system_names = []
+    for model_name in MODELS:
+        model_dir = CALC_PATH / model_name
+        if model_dir.exists():
+            xyz_files = sorted(model_dir.glob("*.xyz"))
+            if xyz_files:
+                for xyz_file in xyz_files:
+                    atoms = read(xyz_file)
+                    system_names.append(atoms.info["system"])
+                break
+    return system_names
+
+
+@pytest.fixture
+@plot_parity(
+    filename=OUT_PATH / "figure_vacancy_formation_energies.json",
+    title="Elemental TM Vacancy Formation Energies",
+    x_label="Predicted Vacancy Formation Energy / eV",
+    y_label="Reference Vacancy Formation Energy / eV",
+    hoverdata={
+        "System": get_system_names(),
+    },
+)
+def vacancy_formation_energies() -> dict[str, list]:
+    """
+    Get vacancy formation energies for all systems.
+
+    Returns
+    -------
+    dict[str, list]
+        Dictionary of reference and predicted vacancy formation energies.
+    """
+    results = {"ref": []} | {mlip: [] for mlip in MODELS}
+    ref_stored = False
+
+    for model_name in MODELS:
+        model_dir = CALC_PATH / model_name
+
+        if not model_dir.exists():
+            continue
+
+        xyz_files = sorted(model_dir.glob("*.xyz"))
+        if not xyz_files:
+            continue
+
+        for xyz_file in xyz_files:
+            structs = read(xyz_file, index=":")
+
+            bulk_energy = structs[0].get_potential_energy()
+            num_atoms = len(structs[0])
+            system = structs[0].info["system"]
+            vacancy_energy = structs[1].get_potential_energy()
+
+            vacancy_formation_energy = (
+                vacancy_energy - ((num_atoms - 1) / num_atoms) * bulk_energy
+            )
+            results[model_name].append(vacancy_formation_energy)
+
+            # Copy individual structure files to app data directory
+            structs_dir = OUT_PATH / model_name
+            structs_dir.mkdir(parents=True, exist_ok=True)
+            write(structs_dir / f"{system}.xyz", structs)
+
+            # Store reference energies (only once)
+            if not ref_stored:
+                results["ref"].append(structs[0].info["ref"])
+
+        ref_stored = True
+
+    return results
+
+
+@pytest.fixture
+def vacancy_formation_errors(vacancy_formation_energies) -> dict[str, float]:
+    """
+    Get mean absolute error for vacancy formation energies.
+
+    Parameters
+    ----------
+    vacancy_formation_energies
+        Dictionary of reference and predicted vacancy formation energies.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary of predicted vacancy formation energy errors for all models.
+    """
+    results = {}
+    for model_name in MODELS:
+        if vacancy_formation_energies[model_name]:
+            results[model_name] = mae(
+                vacancy_formation_energies["ref"],
+                vacancy_formation_energies[model_name],
+            )
+        else:
+            results[model_name] = None
+    return results
+
+
+@pytest.fixture
+@build_table(
+    filename=OUT_PATH / "vacancy_formation_energies_metrics_table.json",
+    metric_tooltips=DEFAULT_TOOLTIPS,
+    thresholds=DEFAULT_THRESHOLDS,
+)
+def metrics(vacancy_formation_errors: dict[str, float]) -> dict[str, dict]:
+    """
+    Get all Vacancy Formation Energies metrics.
+
+    Parameters
+    ----------
+    vacancy_formation_errors
+        Mean absolute errors for all systems.
+
+    Returns
+    -------
+    dict[str, dict]
+        Metric names and values for all models.
+    """
+    return {
+        "MAE": vacancy_formation_errors,
+    }
+
+
+def test_vacancy_formation_energies(metrics: dict[str, dict]) -> None:
+    """
+    Run test to assess a model on elemental TM vac. form. energies.
+
+    Parameters
+    ----------
+    metrics
+        All elemental TM vacancy formation energies metrics.
+    """
+    return

--- a/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/analyse_elemental_tm_vacancies.py
+++ b/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/analyse_elemental_tm_vacancies.py
@@ -24,28 +24,6 @@ DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
 )
 
 
-def get_system_names() -> list[str]:
-    """
-    Get list of all system names.
-
-    Returns
-    -------
-    list[str]
-        List of system names from structure files.
-    """
-    system_names = []
-    for model_name in MODELS:
-        model_dir = CALC_PATH / model_name
-        if model_dir.exists():
-            xyz_files = sorted(model_dir.glob("*.xyz"))
-            if xyz_files:
-                for xyz_file in xyz_files:
-                    atoms = read(xyz_file)
-                    system_names.append(atoms.info["system"])
-                break
-    return system_names
-
-
 INFO = get_struct_info(
     calc_path=CALC_PATH,
     glob_pattern="*.xyz",
@@ -64,7 +42,7 @@ INFO = get_struct_info(
     x_label="Predicted Vacancy Formation Energy / eV",
     y_label="Reference Vacancy Formation Energy / eV",
     hoverdata={
-        "System": get_system_names(),
+        "System": INFO["system"],
     },
 )
 def vacancy_formation_energies() -> dict[str, list]:

--- a/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/analyse_elemental_tm_vacancies.py
+++ b/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/analyse_elemental_tm_vacancies.py
@@ -8,7 +8,7 @@ from ase.io import read, write
 import pytest
 
 from ml_peg.analysis.utils.decorators import build_table, plot_parity
-from ml_peg.analysis.utils.utils import load_metrics_config, mae
+from ml_peg.analysis.utils.utils import get_struct_info, load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
 from ml_peg.models import current_models
@@ -44,6 +44,17 @@ def get_system_names() -> list[str]:
                     system_names.append(atoms.info["system"])
                 break
     return system_names
+
+
+INFO = get_struct_info(
+    calc_path=CALC_PATH,
+    glob_pattern="*.xyz",
+    index="0",
+    info_keys=["system"],
+    write_info=True,
+    write_structs=True,
+    out_path=OUT_PATH,
+)
 
 
 @pytest.fixture

--- a/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/analyse_elemental_tm_vacancies.py
+++ b/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/analyse_elemental_tm_vacancies.py
@@ -11,8 +11,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "bulk_crystal" / "elemental_tm_vacancies" / "outputs"

--- a/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/metrics.yml
+++ b/ml_peg/analysis/bulk_crystal/elemental_tm_vacancies/metrics.yml
@@ -1,0 +1,7 @@
+metrics:
+    MAE:
+        good: 0.05
+        bad: 0.5
+        unit: eV
+        tooltip: "Mean Absolute Error for all systems"
+        level_of_theory: PBE

--- a/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
+++ b/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
+++ b/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
@@ -1,0 +1,87 @@
+"""Run Elemental TM Vacancy app."""
+
+from __future__ import annotations
+
+from dash import Dash
+from dash.html import Div
+
+from ml_peg.app import APP_ROOT
+from ml_peg.app.base_app import BaseApp
+from ml_peg.app.utils.build_callbacks import (
+    plot_from_table_column,
+    struct_from_scatter,
+)
+from ml_peg.app.utils.load import read_plot
+from ml_peg.models.get_models import get_model_names
+from ml_peg.models.models import current_models
+
+# Get all models
+MODELS = get_model_names(current_models)
+BENCHMARK_NAME = "Elemental Transition Metal Vacancy Formation Energies"
+DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/bulk_crystal.html#elemental-tm-vacancy-formation-energies"
+DATA_PATH = APP_ROOT / "data" / "bulk_crystal" / "elemental_tm_vacancies"
+
+
+class ElementalTMVacanciesApp(BaseApp):
+    """Elemental TM Vacancies benchmark app layout and callbacks."""
+
+    def register_callbacks(self) -> None:
+        """Register callbacks to app."""
+        scatter = read_plot(
+            DATA_PATH / "figure_vacancy_formation_energies.json",
+            id=f"{BENCHMARK_NAME}-figure",
+        )
+
+        # Assets dir will be parent directory - individual files for each system
+        structs_dir = DATA_PATH / MODELS[0]
+        structs = [
+            f"assets/bulk_crystal/elemental_tm_vacancies/{MODELS[0]}/{struct_file.stem}.xyz"
+            for struct_file in sorted(structs_dir.glob("*.xyz"))
+        ]
+
+        plot_from_table_column(
+            table_id=self.table_id,
+            plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
+            column_to_plot={"MAE": scatter},
+        )
+
+        struct_from_scatter(
+            scatter_id=f"{BENCHMARK_NAME}-figure",
+            struct_id=f"{BENCHMARK_NAME}-struct-placeholder",
+            structs=structs,
+            mode="traj",
+        )
+
+
+def get_app() -> ElementalTMVacanciesApp:
+    """
+    Get Elemental TM Vacancies benchmark app layout and callback registration.
+
+    Returns
+    -------
+    ElementalTMVacanciesApp
+        Benchmark layout and callback registration.
+    """
+    return ElementalTMVacanciesApp(
+        name=BENCHMARK_NAME,
+        description="Vacancy formation energies for 42 elemental TM structures.",
+        docs_url=DOCS_URL,
+        table_path=DATA_PATH / "vacancy_formation_energies_metrics_table.json",
+        extra_components=[
+            Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
+            Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
+        ],
+    )
+
+
+if __name__ == "__main__":
+    # Create Dash app
+    full_app = Dash(__name__, assets_folder=DATA_PATH.parent.parent)
+
+    # Construct layout and register callbacks
+    elemental_tm_vacancies_app = get_app()
+    full_app.layout = elemental_tm_vacancies_app.layout
+    elemental_tm_vacancies_app.register_callbacks()
+
+    # Run app
+    full_app.run(port=8055, debug=True)

--- a/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
+++ b/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
@@ -20,6 +20,7 @@ MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "Elemental Transition Metal Vacancy Formation Energies"
 DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/bulk_crystal.html#elemental-tm-vacancy-formation-energies"
 DATA_PATH = APP_ROOT / "data" / "bulk_crystal" / "elemental_tm_vacancies"
+INFO_PATH = DATA_PATH / "info.json"
 
 
 class ElementalTMVacanciesApp(BaseApp):

--- a/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
+++ b/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
@@ -72,6 +72,7 @@ def get_app() -> ElementalTMVacanciesApp:
             Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
             Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
         ],
+        info_path=INFO_PATH,
     )
 
 

--- a/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
+++ b/ml_peg/app/bulk_crystal/elemental_tm_vacancies/app_elemental_tm_vacancies.py
@@ -35,7 +35,7 @@ class ElementalTMVacanciesApp(BaseApp):
         # Assets dir will be parent directory - individual files for each system
         structs_dir = DATA_PATH / MODELS[0]
         structs = [
-            f"assets/bulk_crystal/elemental_tm_vacancies/{MODELS[0]}/{struct_file.stem}.xyz"
+            f"/assets/bulk_crystal/elemental_tm_vacancies/{MODELS[0]}/{struct_file.stem}.xyz"
             for struct_file in sorted(structs_dir.glob("*.xyz"))
         ]
 

--- a/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
+++ b/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
@@ -1,0 +1,77 @@
+"""Run calculations for Elemental Transition Metal Vacancy Formation tests."""
+
+from __future__ import annotations
+
+from copy import copy
+from pathlib import Path
+from typing import Any
+
+from ase.io import read, write
+import numpy as np
+import pytest
+
+from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models.get_models import load_models
+from ml_peg.models.models import current_models
+
+MODELS = load_models(current_models)
+
+DATA_PATH = Path(__file__).parent / "data"
+OUT_PATH = Path(__file__).parent / "outputs"
+
+
+@pytest.mark.parametrize("mlip", MODELS.items())
+def test_vacancy_formation_energy(mlip: tuple[str, Any]) -> None:
+    """
+    Run vacancy formation energy test.
+
+    Parameters
+    ----------
+    mlip
+        Name of model use and model to get calculator.
+    """
+    model_name, model = mlip
+    calc = model.get_calculator()
+
+    # Download dataset
+    elemental_tm_vacancies_dir = (
+        download_s3_data(
+            key="inputs/bulk_crystal/elemental_tm_vacancies/Elemental_TM_Vacancy.zip",
+            filename="Elemental_TM_Vacancy.zip",
+        )
+        / "Elemental_TM_Vacancy"
+    )
+
+    with open(elemental_tm_vacancies_dir / "list") as f:
+        systems = f.read().splitlines()
+
+    for system in systems:
+        bulk_path = elemental_tm_vacancies_dir / system / "CONTCAR_bulk"
+        vacancy_path = elemental_tm_vacancies_dir / system / "CONTCAR_vacancy"
+        ref_path = elemental_tm_vacancies_dir / system / "vacancy_formation_energy_PBE"
+
+        bulk = read(bulk_path, index=0, format="vasp")
+        # Set default charge and spin
+        bulk.info.setdefault("charge", 0)
+        bulk.info.setdefault("spin", 1)
+        bulk.calc = calc
+        bulk.get_potential_energy()
+
+        vacancy = read(vacancy_path, index=0, format="vasp")
+        # Set default charge and spin
+        vacancy.info.setdefault("charge", 0)
+        vacancy.info.setdefault("spin", 1)
+        vacancy.calc = copy(calc)
+        vacancy.get_potential_energy()
+
+        ref = np.loadtxt(ref_path)
+
+        bulk.info["ref"] = ref
+        bulk.info["system"] = system
+        vacancy.info["ref"] = ref
+        vacancy.info["system"] = system
+
+        # Write output structures
+        write_dir = OUT_PATH / model_name
+        write_dir.mkdir(parents=True, exist_ok=True)
+        write(write_dir / f"{system}.xyz", [bulk, vacancy])

--- a/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
+++ b/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
@@ -36,10 +36,10 @@ def test_vacancy_formation_energy(mlip: tuple[str, Any]) -> None:
     # Download dataset
     elemental_tm_vacancies_dir = (
         download_s3_data(
-            key="inputs/bulk_crystal/elemental_tm_vacancies/Elemental_TM_Vacancy.zip",
-            filename="Elemental_TM_Vacancy.zip",
+            key="inputs/bulk_crystal/elemental_tm_vacancies/elemental_tm_vacancies.zip",
+            filename="elemental_tm_vacancies.zip",
         )
-        / "Elemental_TM_Vacancy"
+        / "elemental_tm_vacancies"
     )
 
     with open(elemental_tm_vacancies_dir / "list") as f:

--- a/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
+++ b/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from copy import copy
 from pathlib import Path
 from typing import Any
+from warnings import warn
 
 from ase.io import read, write
 import numpy as np
@@ -54,14 +55,22 @@ def test_vacancy_formation_energy(mlip: tuple[str, Any]) -> None:
         bulk.info.setdefault("charge", 0)
         bulk.info.setdefault("spin", 1)
         bulk.calc = calc
-        bulk.get_potential_energy()
+        try:
+            bulk.get_potential_energy()
+        except Exception as exc:
+            warn(f"Error calculating energy: {exc}", stacklevel=2)
+            bulk.info["energy"] = np.nan
 
         vacancy = read(vacancy_path, index=0, format="vasp")
         # Set default charge and spin
         vacancy.info.setdefault("charge", 0)
         vacancy.info.setdefault("spin", 1)
         vacancy.calc = copy(calc)
-        vacancy.get_potential_energy()
+        try:
+            vacancy.get_potential_energy()
+        except Exception as exc:
+            warn(f"Error calculating energy: {exc}", stacklevel=2)
+            vacancy.info["energy"] = np.nan
 
         ref = np.loadtxt(ref_path)
 

--- a/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
+++ b/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
@@ -11,8 +11,8 @@ import numpy as np
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
+++ b/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
@@ -31,7 +31,7 @@ def test_vacancy_formation_energy(mlip: tuple[str, Any]) -> None:
         Name of model use and model to get calculator.
     """
     model_name, model = mlip
-    calc = model.get_calculator()
+    calc = model.get_calculator(precision="high")
 
     # Download dataset
     elemental_tm_vacancies_dir = (

--- a/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
+++ b/ml_peg/calcs/bulk_crystal/elemental_tm_vacancies/calc_elemental_tm_vacancies.py
@@ -16,7 +16,6 @@ from ml_peg.models.get_models import load_models
 
 MODELS = load_models(current_models)
 
-DATA_PATH = Path(__file__).parent / "data"
 OUT_PATH = Path(__file__).parent / "outputs"
 
 


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to a "new benchmark" issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

<!-- Summarise the new benchmark. This can be brief, as most information should be in the linked issue. -->

This benchmark looks to assess the performance of the models in predicting vacancy formation energies for 42 fcc or hcp elemental transition metal structures. This is done by assessing mean absolute errors (MAEs) between predicted and reference (PBE) vacancy formation energies values. For each elemental transition metal structure, the vacancy formation enthalpy is determined by evaluating the total energy of the cell containing the monovacancy and evaluating the total energy of the undefected cell and comparing these. Note: the undefected cell energy is scaled by a fraction in order to conserve the appropriate number of atoms.

## Linked issue

<!-- Enter the number of the issue this resolves. This should be labelled as "new benchmark". -->
Resolves #318

## Progress

<!-- Which aspects of adding the new benchmark are complete? Any issues encountered can also be discussed here. -->
- [x] Calculations
- [x] Analysis
- [x] Application
- [x] Documentation

## Testing

<!-- Which models have you tested your benchmark on? -->

Models tested:
mace-matpes-r2scan
mace-mp-0a
mace-mp-0b3
mace-mpa-0
mace-omat-0
orb-v3-consv-inf-omat
pet-mad
## New decorators/callbacks

<!-- Are new callbacks required for the interactivity you need? -->

No