### PR TITLE
Fix setting MACE default dtype

### DIFF
--- a/ml_peg/models/get_models.py
+++ b/ml_peg/models/get_models.py
@@ -108,54 +108,55 @@ def load_models(models: None | str | Iterable = None) -> dict[str, Any]:
     for name, cfg in get_subset(all_models, models).items():
         print(f"Loading model from models.yml: {name}")
 
-        if cfg["class_name"] == "FAIRChemCalculator":
-            kwargs = cfg.get("kwargs", {})
-            loaded_models[name] = FairChemCalc(
-                model_name=kwargs["model_name"],
-                task_name=kwargs.get("task_name", "omat"),
-                device=cfg.get("device", "cpu"),
-                overrides=kwargs.get("overrides", {}),
-                trained_on_d3=cfg.get("trained_on_d3", False),
-                d3_kwargs=cfg.get("d3_kwargs", {}),
-            )
-        elif cfg["class_name"] == "OrbCalc":
-            kwargs = cfg.get("kwargs", {})
-            loaded_models[name] = OrbCalc(
-                name=kwargs["name"],
-                device=cfg.get("device", "cpu"),
-                default_dtype=cfg.get("default_dtype", "float32"),
-                trained_on_d3=cfg.get("trained_on_d3", False),
-                d3_kwargs=cfg.get("d3_kwargs", {}),
-            )
-        elif cfg["class_name"] == "mace_mp":
-            loaded_models[name] = GenericASECalc(
-                module=cfg["module"],
-                class_name=cfg["class_name"],
-                device=cfg.get("device", "auto"),
-                default_dtype=cfg.get("default_dtype", "float32"),
-                kwargs=cfg.get("kwargs", {}),
-                trained_on_d3=cfg.get("trained_on_d3", False),
-                d3_kwargs=cfg.get("d3_kwargs", {}),
-            )
-        elif cfg["class_name"] == "PETMADCalculator":
-            loaded_models[name] = PetMadCalc(
-                module=cfg["module"],
-                class_name=cfg["class_name"],
-                device=cfg.get("device", "cpu"),
-                default_dtype=cfg.get("default_dtype", "float32"),
-                kwargs=cfg.get("kwargs", {}),
-                trained_on_d3=cfg.get("trained_on_d3", False),
-                d3_kwargs=cfg.get("d3_kwargs", {}),
-            )
-        else:
-            loaded_models[name] = GenericASECalc(
-                module=cfg["module"],
-                class_name=cfg["class_name"],
-                device=cfg.get("device", "auto"),
-                kwargs=cfg.get("kwargs", {}),
-                trained_on_d3=cfg.get("trained_on_d3", False),
-                d3_kwargs=cfg.get("d3_kwargs", {}),
-            )
+        match cfg["class_name"]:
+            case "FAIRChemCalculator":
+                kwargs = cfg.get("kwargs", {})
+                loaded_models[name] = FairChemCalc(
+                    model_name=kwargs["model_name"],
+                    task_name=kwargs.get("task_name", "omat"),
+                    device=cfg.get("device", "cpu"),
+                    overrides=kwargs.get("overrides", {}),
+                    trained_on_d3=cfg.get("trained_on_d3", False),
+                    d3_kwargs=cfg.get("d3_kwargs", {}),
+                )
+            case "OrbCalc":
+                kwargs = cfg.get("kwargs", {})
+                loaded_models[name] = OrbCalc(
+                    name=kwargs["name"],
+                    device=cfg.get("device", "cpu"),
+                    default_dtype=cfg.get("default_dtype", "float32"),
+                    trained_on_d3=cfg.get("trained_on_d3", False),
+                    d3_kwargs=cfg.get("d3_kwargs", {}),
+                )
+            case "mace" | "mace_mp" | "mace_off" | "mace_omol" | "mace_polar":
+                loaded_models[name] = GenericASECalc(
+                    module=cfg["module"],
+                    class_name=cfg["class_name"],
+                    device=cfg.get("device", "auto"),
+                    default_dtype=cfg.get("default_dtype", "float32"),
+                    kwargs=cfg.get("kwargs", {}),
+                    trained_on_d3=cfg.get("trained_on_d3", False),
+                    d3_kwargs=cfg.get("d3_kwargs", {}),
+                )
+            case "PETMADCalculator":
+                loaded_models[name] = PetMadCalc(
+                    module=cfg["module"],
+                    class_name=cfg["class_name"],
+                    device=cfg.get("device", "cpu"),
+                    default_dtype=cfg.get("default_dtype", "float32"),
+                    kwargs=cfg.get("kwargs", {}),
+                    trained_on_d3=cfg.get("trained_on_d3", False),
+                    d3_kwargs=cfg.get("d3_kwargs", {}),
+                )
+            case _:
+                loaded_models[name] = GenericASECalc(
+                    module=cfg["module"],
+                    class_name=cfg["class_name"],
+                    device=cfg.get("device", "auto"),
+                    kwargs=cfg.get("kwargs", {}),
+                    trained_on_d3=cfg.get("trained_on_d3", False),
+                    d3_kwargs=cfg.get("d3_kwargs", {}),
+                )
 
     return loaded_models
 


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Fixes setting default dtype for MACE models that other than those accessed via `mace_mp`.

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #381

## Testing

Tested locally for mace_omol and mace_polar