### PR TITLE
Add loading wheels to site load and tab switching

### DIFF
--- a/ml_peg/app/build_app.py
+++ b/ml_peg/app/build_app.py
@@ -384,8 +384,22 @@ def build_tabs(
                 Tabs(id="all-tabs", value="summary-tab", children=all_tabs),
                 Loading(
                     Div(id="tabs-content"),
-                    type="default",
+                    type="circle",
                     color="#119DFF",
+                    fullscreen=False,
+                    # dont trigger both start up load wheel + tab change load wheel
+                    # (when switching to summary tab)
+                    target_components={"tabs-content": "children"},
+                    style={
+                        # Pin near the top so the spinner is visible on long pages
+                        # (default is centre of page)
+                        "position": "fixed",
+                        "top": "300px",
+                        "left": "50%",
+                        "transform": "translateX(-50%)",
+                        "zIndex": "1100",
+                    },
+                    parent_style={"position": "relative"},
                 ),
             ],
             style={"flex": "1", "marginBottom": "40px"},
@@ -393,14 +407,9 @@ def build_tabs(
         build_footer(),
     ]
 
-    full_app.layout = Loading(
-        Div(
-            tabs_layout,
-            style={"display": "flex", "flexDirection": "column", "minHeight": "100vh"},
-        ),
-        type="default",
-        fullscreen=True,
-        color="#119DFF",
+    full_app.layout = Div(
+        tabs_layout,
+        style={"display": "flex", "flexDirection": "column", "minHeight": "100vh"},
     )
 
     @callback(Output("tabs-content", "children"), Input("all-tabs", "value"))


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

<!-- Describe your proposed changes. This can be brief, as most information can be in the linked issue. -->
Added loading wheels to site load and tab switching. also made sure when switching back to summary tab we only trigger the tab switch load and not site load load
## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #

## Testing
site load and tab switch
<!-- How have your proposed changes been tested? -->
