### PR TITLE
apply configured weights

### DIFF
--- a/ml_peg/app/build_app.py
+++ b/ml_peg/app/build_app.py
@@ -254,7 +254,7 @@ def build_summary_table(
             row[category_col] = summary_data[mlip].get(category_col, None)
         data.append(row)
 
-    data = calc_table_scores(data)
+    data = calc_table_scores(data, weights=weights)
 
     columns_headers = ("MLIP",) + tuple(key + " Score" for key in tables) + ("Score",)
 


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary
In pr #376 we didnt update the initial summary table to use the configured weights. This means to get the configured weight instead of just 1 for all weights, we need to click on a tab and hten return to the summary tab. This simple fix just applies the configured weights to the initially loaded summary table
<!-- Describe your proposed changes. This can be brief, as most information can be in the linked issue. -->

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #431 

## Testing
comparing scores, changing tabs etc
<!-- How have your proposed changes been tested? -->
