### PR TITLE
⚡ Bolt: Prevent repetitive models.yml parsing via lru_cache in get_models

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-04-13 - Cached model configuration loading
+**Learning:** The application calls `get_model_names` frequently during startup (it's called in many files at import time). This repeatedly parsed the `models.yml` YAML file, significantly slowing down the app load time due to YAML parsing overhead.
+**Action:** Used `functools.lru_cache` to cache the loaded dictionary from `models.yml` and reuse it across `get_model_names` calls.

--- a/ml_peg/models/get_models.py
+++ b/ml_peg/models/get_models.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from copy import deepcopy
+from functools import lru_cache
 from typing import Any
 
 import yaml
@@ -30,8 +31,7 @@ def load_model_configs(
         - model_levels: Dictionary mapping model names to their level of
           theory (or ``None``)
     """
-    with open(MODELS_ROOT / "models.yml", encoding="utf8") as model_file:
-        all_models = yaml.safe_load(model_file) or {}
+    all_models = _load_all_models_dict()
 
     model_levels: dict[str, str | None] = {}
     model_configs: dict[str, Any] = {}
@@ -101,9 +101,7 @@ def load_models(models: None | str | Iterable = None) -> dict[str, Any]:
 
     loaded_models = {}
 
-    # Load models from registry YAML: models.yml
-    with open(MODELS_ROOT / "models.yml") as file:
-        all_models = yaml.safe_load(file)
+    all_models = _load_all_models_dict()
 
     for name, cfg in get_subset(all_models, models).items():
         print(f"Loading model from models.yml: {name}")
@@ -161,6 +159,11 @@ def load_models(models: None | str | Iterable = None) -> dict[str, Any]:
     return loaded_models
 
 
+@lru_cache(maxsize=1)
+def _load_all_models_dict() -> dict[str, Any]:
+    with open(MODELS_ROOT / "models.yml", encoding="utf8") as file:
+        return yaml.safe_load(file) or {}
+
 def get_model_names(models: None | Iterable = None) -> list[str]:
     """
     Load models names for use in analysis.
@@ -177,9 +180,7 @@ def get_model_names(models: None | Iterable = None) -> list[str]:
     list[str]
         Loaded model names from models.yml.
     """
-    # Load models from registry YAML: models.yml
-    with open(MODELS_ROOT / "models.yml") as file:
-        all_models = yaml.safe_load(file)
+    all_models = _load_all_models_dict()
 
     model_names = []
     for name in get_subset(all_models, models):

--- a/ml_peg/models/get_models.py
+++ b/ml_peg/models/get_models.py
@@ -161,8 +161,17 @@ def load_models(models: None | str | Iterable = None) -> dict[str, Any]:
 
 @lru_cache(maxsize=1)
 def _load_all_models_dict() -> dict[str, Any]:
+    """
+    Load and cache models dictionary from models.yml.
+
+    Returns
+    -------
+    dict[str, Any]
+        Loaded models from models.yml.
+    """
     with open(MODELS_ROOT / "models.yml", encoding="utf8") as file:
         return yaml.safe_load(file) or {}
+
 
 def get_model_names(models: None | Iterable = None) -> list[str]:
     """


### PR DESCRIPTION
Added caching to prevent multiple repetitive slow parsing cycles of `models.yml` across numerous modules during app initialization.

This change is non-breaking and does not sacrifice readability. Tests have verified there are no regressions.

---
*PR created automatically by Jules for task [14444627498823028537](https://jules.google.com/task/14444627498823028537) started by @alinelena*