### PR TITLE
Add max steps to geomopt before MD

### DIFF
--- a/ml_peg/calcs/molecular/BMIMCl_RDF/calc_BMIMCl_RDF.py
+++ b/ml_peg/calcs/molecular/BMIMCl_RDF/calc_BMIMCl_RDF.py
@@ -59,7 +59,7 @@ def test_bmimcl_md(mlip: tuple[str, Any]) -> None:
     box.calc = calc
 
     opt = LBFGS(box)
-    opt.run(fmax=0.1)
+    opt.run(fmax=0.1, steps=1000)
 
     MaxwellBoltzmannDistribution(box, temperature_K=TEMPERATURE)
 


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Reduces the max geomopt steps from the default (100_000_000) to 1000, which can be an issue if a model is unable to find a minimum.

@PythonFZ, are you happy with this change?

## Testing

Tested for several models locally.
