### PR TITLE
Add summary info

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,47 @@ pytest -v  # Discover and run all tests
 Please refer to the [online documentation](https://ddmms.github.io/ml-peg/developer_guide/index.html)
 for information about contributing new benchmarks and models.
 
+
+### Command-line interface
+
+To help run calculations, analysis, and the application, we provide the `ml_peg`
+command line tool, which is installed with the package. This provides the following
+commands:
+
+```shell
+ml_peg app
+ml_peg calc
+ml_peg analyse
+ml_peg download
+ml_peg info
+```
+
+For example, to run the X23 test with mace-mp-0a and orb-v3-consv-inf-omat, you can run:
+
+```shell
+ml_peg calc --test X23 --models mace-mp-0a,orb-v3-consv-inf-omat
+```
+
+A description of each subcommand, as well as valid options, can be listed using the
+`--help` option. For example:
+
+```shell
+ml_peg calc --help
+```
+
+The `ml_peg info` command provides a further set of subcommands:
+
+```shell
+ml_peg info calc
+ml_peg info analysis
+ml_peg info app
+ml_peg info models
+```
+
+which list the available tests and categories that may be run for `ml_peg calc`,
+`ml_peg analyse` and `ml_peg app`, and the MLIPs that these can be run for.
+
+
 ### Tutorials
 
 We encourage developers new to the ML-PEG framework to work through the detailed

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ ml_peg app
 ml_peg calc
 ml_peg analyse
 ml_peg download
-ml_peg info
+ml_peg list
 ```
 
 For example, to run the X23 test with mace-mp-0a and orb-v3-consv-inf-omat, you can run:
@@ -93,13 +93,13 @@ A description of each subcommand, as well as valid options, can be listed using 
 ml_peg calc --help
 ```
 
-The `ml_peg info` command provides a further set of subcommands:
+The `ml_peg list` command provides a further set of subcommands:
 
 ```shell
-ml_peg info calc
-ml_peg info analysis
-ml_peg info app
-ml_peg info models
+ml_peg list calcs
+ml_peg list analysis
+ml_peg list app
+ml_peg list models
 ```
 
 which list the available tests and categories that may be run for `ml_peg calc`,

--- a/docs/source/developer_guide/cli.rst
+++ b/docs/source/developer_guide/cli.rst
@@ -10,7 +10,7 @@ commands::
     ml_peg calc
     ml_peg analyse
     ml_peg download
-    ml_peg info
+    ml_peg list
 
 
 For example, to run the X23 test with mace-mp-0a and orb-v3-consv-inf-omat, you can run::
@@ -24,13 +24,13 @@ A description of each subcommand, as well as valid options, can be listed using 
 
     ml_peg calc --help
 
-The ``ml_peg info`` command provides a further set of subcommands::
+The ``ml_peg list`` command provides a further set of subcommands::
 
 
-    ml_peg info calc
-    ml_peg info analysis
-    ml_peg info app
-    ml_peg info models
+    ml_peg list calcs
+    ml_peg list analysis
+    ml_peg list app
+    ml_peg list models
 
 
 which list the available tests and categories that may be run for ``ml_peg calc``,

--- a/docs/source/developer_guide/cli.rst
+++ b/docs/source/developer_guide/cli.rst
@@ -1,0 +1,37 @@
+======================
+Command line interface
+======================
+
+To help run calculations, analysis, and the application, we provide the ``ml_peg``
+command line tool, which is installed with the package. This provides the following
+commands::
+
+    ml_peg app
+    ml_peg calc
+    ml_peg analyse
+    ml_peg download
+    ml_peg info
+
+
+For example, to run the X23 test with mace-mp-0a and orb-v3-consv-inf-omat, you can run::
+
+    ml_peg calc --test X23 --models mace-mp-0a,orb-v3-consv-inf-omat
+
+
+A description of each subcommand, as well as valid options, can be listed using the
+``--help`` option. For example::
+
+
+    ml_peg calc --help
+
+The ``ml_peg info`` command provides a further set of subcommands::
+
+
+    ml_peg info calc
+    ml_peg info analysis
+    ml_peg info app
+    ml_peg info models
+
+
+which list the available tests and categories that may be run for ``ml_peg calc``,
+``ml_peg analyse`` and ``ml_peg app``, and the MLIPs that these can be run for.

--- a/docs/source/developer_guide/index.rst
+++ b/docs/source/developer_guide/index.rst
@@ -7,6 +7,7 @@ Developer guide
 
     get_started
     llm_agent_integration
+    cli
     add_benchmarks
     add_category
     running

--- a/ml_peg/cli/cli.py
+++ b/ml_peg/cli/cli.py
@@ -274,18 +274,24 @@ def run_analysis(
     pytest.main(options)
 
 
-info_app = Typer(
-    name="info",
+list_app = Typer(
+    name="list",
     no_args_is_help=True,
-    epilog="Try 'ml_peg info COMMAND --help' for subcommand options",
+    epilog="Try 'ml_peg list COMMAND --help' for subcommand options",
 )
-app.add_typer(info_app, help="Get info for calculations, analysis, and apps.")
+app.add_typer(
+    list_app,
+    help=(
+        "List available categories, tests, and models for calculations, analysis, and "
+        "app."
+    ),
+)
 
 
-@info_app.command(
-    name="calc", help="List categories and tests available for calculations"
+@list_app.command(
+    name="calcs", help="List categories and tests available for calculations"
 )
-def calc_info(
+def list_calcs(
     category: Annotated[
         CalcCategories,
         Option(
@@ -295,12 +301,12 @@ def calc_info(
     ] = "*",
 ):
     """
-    Return information about current tests and categories available for calculations.
+    List categories and tests available for calculations.
 
     Parameters
     ----------
     category
-        Category to get test info for. Default is `*`, corresponding to all categories.
+        Category to list test for. Default is `*`, corresponding to all categories.
     """
     if category == "*":
         print(
@@ -313,25 +319,25 @@ def calc_info(
     print(f"Tests: {', '.join(get_tests(CALCS_ROOT, 'calc', category))}")
 
 
-@info_app.command(
+@list_app.command(
     name="analysis", help="List categories and tests available for analysis"
 )
-def analysis_info(
+def list_analysis(
     category: Annotated[
         AnalysisCategories,
         Option(
-            help="Category to get test info for. Default is all categories.",
+            help="Category to list tests for. Default is all categories.",
             case_sensitive=False,
         ),
     ] = "*",
 ):
     """
-    Return information about current tests and categories available for analysis.
+    List categories and tests available for analysis.
 
     Parameters
     ----------
     category
-        Category to get test info for. Default is `*`, corresponding to all categories.
+        Category to list tests for. Default is `*`, corresponding to all categories.
     """
     if category == "*":
         print(
@@ -346,25 +352,25 @@ def analysis_info(
     print(f"Tests: {', '.join(get_tests(ANALYSIS_ROOT, 'analyse', category))}")
 
 
-@info_app.command(
-    name="app", help="List categories and tests available for application"
+@list_app.command(
+    name="app", help="List categories and tests available as applications"
 )
-def app_info(
+def list_apps(
     category: Annotated[
         AppCategories,
         Option(
-            help="Category to get test info for. Default is all categories.",
+            help="Category to list tests for. Default is all categories.",
             case_sensitive=False,
         ),
     ] = "*",
 ):
     """
-    Return information about current tests and categories available for app.
+    List categories and tests available as applications.
 
     Parameters
     ----------
     category
-        Category to get test info for. Default is `*`, corresponding to all categories.
+        Category to list tests for. Default is `*`, corresponding to all categories.
     """
     if category == "*":
         print(
@@ -377,9 +383,9 @@ def app_info(
     print(f"Tests: {', '.join(get_tests(ANALYSIS_ROOT, 'analyse', category))}")
 
 
-@info_app.command(name="models", help="List models currently available")
-def models_info() -> None:
-    """Return information about current models."""
+@list_app.command(name="models", help="List models currently available")
+def list_models() -> None:
+    """List currently available models."""
     from ml_peg.models.get_models import get_model_names
 
     print(f"Available models: {', '.join(get_model_names())}")

--- a/ml_peg/cli/cli.py
+++ b/ml_peg/cli/cli.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Literal
+from typing import Annotated, Literal, get_args
 
 from typer import Context, Exit, Option, Typer
 
@@ -30,7 +30,7 @@ def get_categories(root: Path, script_prefix: str) -> tuple[str, ...]:
         Tuple of sorted category names. Uses glob matches for `script_prefix` within
         the `root` directory.
     """
-    return tuple(
+    return ("*",) + tuple(
         sorted(
             {
                 path.parent.parent.name
@@ -41,9 +41,42 @@ def get_categories(root: Path, script_prefix: str) -> tuple[str, ...]:
     )
 
 
-AnalysisCategories = Literal[("*",) + (get_categories(ANALYSIS_ROOT, "analyse"))]
-AppCategories = Literal[("*",) + (get_categories(APP_ROOT, "app"))]
-CalculationCategories = Literal[("*",) + (get_categories(CALCS_ROOT, "calc"))]
+def get_tests(root: Path, script_prefix: str, category: str = "*") -> tuple[str, ...]:
+    """
+    Get current tests.
+
+    Parameters
+    ----------
+    root
+        Root directory to search for tests in.
+    script_prefix
+        Prefix of script files to match for e.g. "calc" for calc_test.py.
+    category
+        Category in which to search for tests. Default is `*`, corresponding to all
+        categories.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Tuple of sorted test names. Uses glob matches for `script_prefix` within
+        the `root` directory.
+    """
+    return tuple(
+        sorted(
+            {
+                path.parent.name
+                for path in root.glob(f"{category}/*/{script_prefix}_*.py")
+                if path.is_file()
+                and path.parent.is_dir()
+                and path.name == f"{script_prefix}_{path.parent.name}.py"
+            }
+        )
+    )
+
+
+AnalysisCategories = Literal[(get_categories(ANALYSIS_ROOT, "analyse"))]
+AppCategories = Literal[(get_categories(APP_ROOT, "app"))]
+CalcCategories = Literal[(get_categories(CALCS_ROOT, "calc"))]
 
 
 app = Typer(
@@ -110,7 +143,7 @@ def run_calcs(
         ),
     ] = None,
     category: Annotated[
-        CalculationCategories,
+        CalcCategories,
         Option(help="Category to run calculations for. Default is all categories."),
     ] = "*",
     test: Annotated[
@@ -230,6 +263,94 @@ def run_analysis(
         options.extend(["--models", models])
 
     pytest.main(options)
+
+
+info_app = Typer(
+    name="info",
+    no_args_is_help=True,
+    epilog="Try 'ml_peg info COMMAND --help' for subcommand options",
+)
+app.add_typer(info_app, help="Get info for calculations, analysis, and apps.")
+
+
+@info_app.command(name="calc", help="Get categories info")
+def calc_info(
+    category: Annotated[
+        CalcCategories,
+        Option(help="Category to run calculations for. Default is all categories."),
+    ] = "*",
+):
+    """
+    Return information about current tests and categories available for calculations.
+
+    Parameters
+    ----------
+    category
+        Category to get test info for. Default is `*`, corresponding to all categories.
+    """
+    if category == "*":
+        print(
+            f"Categories: {
+                ', '.join(
+                    category for category in get_args(CalcCategories) if category != '*'
+                )
+            }\n"
+        )
+    print(f"Tests: {', '.join(get_tests(CALCS_ROOT, 'calc', category))}")
+
+
+@info_app.command(name="analysis", help="Get analysis info")
+def analysis_info(
+    category: Annotated[
+        AnalysisCategories,
+        Option(help="Category to get test info for. Default is all categories."),
+    ] = "*",
+):
+    """
+    Return information about current tests and categories available for analysis.
+
+    Parameters
+    ----------
+    category
+        Category to get test info for. Default is `*`, corresponding to all categories.
+    """
+    if category == "*":
+        print(
+            f"Categories: {
+                ', '.join(
+                    category
+                    for category in get_args(AnalysisCategories)
+                    if category != '*'
+                )
+            }\n"
+        )
+    print(f"Tests: {', '.join(get_tests(ANALYSIS_ROOT, 'analyse', category))}")
+
+
+@info_app.command(name="app", help="Get app info")
+def app_info(
+    category: Annotated[
+        AppCategories,
+        Option(help="Category to get test info for. Default is all categories."),
+    ] = "*",
+):
+    """
+    Return information about current tests and categories available for app.
+
+    Parameters
+    ----------
+    category
+        Category to get test info for. Default is `*`, corresponding to all categories.
+    """
+    if category == "*":
+        print(
+            f"Categories: {
+                ', '.join(
+                    category for category in get_args(AppCategories) if category != '*'
+                )
+            }\n"
+        )
+    print(f"Tests: {', '.join(get_tests(ANALYSIS_ROOT, 'analyse', category))}")
 
 
 @app.command(name="download", help="Download data from S3 bucket")

--- a/ml_peg/cli/cli.py
+++ b/ml_peg/cli/cli.py
@@ -2,11 +2,49 @@
 
 from __future__ import annotations
 
-from typing import Annotated
+from pathlib import Path
+from typing import Annotated, Literal
 
 from typer import Context, Exit, Option, Typer
 
 from ml_peg import __version__
+from ml_peg.analysis import ANALYSIS_ROOT
+from ml_peg.app import APP_ROOT
+from ml_peg.calcs import CALCS_ROOT
+
+
+def get_categories(root: Path, script_prefix: str) -> tuple[str, ...]:
+    """
+    Get current categories.
+
+    Parameters
+    ----------
+    root
+        Root directory to search for categories in.
+    script_prefix
+        Prefix of script files to match for e.g. "calc" for calc_test.py.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Tuple of sorted category names. Uses glob matches for `script_prefix` within
+        the `root` directory.
+    """
+    return tuple(
+        sorted(
+            {
+                path.parent.parent.name
+                for path in root.glob(f"*/*/{script_prefix}_*.py")
+                if path.is_file() and path.parent.parent.is_dir()
+            }
+        )
+    )
+
+
+AnalysisCategories = Literal[("*",) + (get_categories(ANALYSIS_ROOT, "analyse"))]
+AppCategories = Literal[("*",) + (get_categories(APP_ROOT, "app"))]
+CalculationCategories = Literal[("*",) + (get_categories(CALCS_ROOT, "calc"))]
+
 
 app = Typer(
     name="ml_peg",
@@ -27,7 +65,8 @@ def run_dash_app(
         ),
     ] = None,
     category: Annotated[
-        str, Option(help="Category to build app for. Default is all categories.")
+        AppCategories,
+        Option(help="Category to build app for. Default is all categories."),
     ] = "*",
     port: Annotated[str, Option(help="Port to run application on.")] = 8050,
     debug: Annotated[bool, Option(help="Whether to run with Dash debugging.")] = True,
@@ -71,7 +110,8 @@ def run_calcs(
         ),
     ] = None,
     category: Annotated[
-        str, Option(help="Category to run calculations for. Default is all categories.")
+        CalculationCategories,
+        Option(help="Category to run calculations for. Default is all categories."),
     ] = "*",
     test: Annotated[
         str, Option(help="Test to run calculations for. Default is all tests.")
@@ -146,7 +186,8 @@ def run_analysis(
         ),
     ] = None,
     category: Annotated[
-        str, Option(help="Category to run analysis for. Default is all categories.")
+        AnalysisCategories,
+        Option(help="Category to run analysis for. Default is all categories."),
     ] = "*",
     test: Annotated[
         str, Option(help="Test to run analysis for. Default is all tests.")

--- a/ml_peg/cli/cli.py
+++ b/ml_peg/cli/cli.py
@@ -99,7 +99,10 @@ def run_dash_app(
     ] = None,
     category: Annotated[
         AppCategories,
-        Option(help="Category to build app for. Default is all categories."),
+        Option(
+            help="Category to build app for. Default is all categories.",
+            case_sensitive=False,
+        ),
     ] = "*",
     port: Annotated[str, Option(help="Port to run application on.")] = 8050,
     debug: Annotated[bool, Option(help="Whether to run with Dash debugging.")] = True,
@@ -144,7 +147,10 @@ def run_calcs(
     ] = None,
     category: Annotated[
         CalcCategories,
-        Option(help="Category to run calculations for. Default is all categories."),
+        Option(
+            help="Category to run calculations for. Default is all categories.",
+            case_sensitive=False,
+        ),
     ] = "*",
     test: Annotated[
         str, Option(help="Test to run calculations for. Default is all tests.")
@@ -220,7 +226,10 @@ def run_analysis(
     ] = None,
     category: Annotated[
         AnalysisCategories,
-        Option(help="Category to run analysis for. Default is all categories."),
+        Option(
+            help="Category to run analysis for. Default is all categories.",
+            case_sensitive=False,
+        ),
     ] = "*",
     test: Annotated[
         str, Option(help="Test to run analysis for. Default is all tests.")
@@ -277,7 +286,10 @@ app.add_typer(info_app, help="Get info for calculations, analysis, and apps.")
 def calc_info(
     category: Annotated[
         CalcCategories,
-        Option(help="Category to run calculations for. Default is all categories."),
+        Option(
+            help="Category to run calculations for. Default is all categories.",
+            case_sensitive=False,
+        ),
     ] = "*",
 ):
     """
@@ -303,7 +315,10 @@ def calc_info(
 def analysis_info(
     category: Annotated[
         AnalysisCategories,
-        Option(help="Category to get test info for. Default is all categories."),
+        Option(
+            help="Category to get test info for. Default is all categories.",
+            case_sensitive=False,
+        ),
     ] = "*",
 ):
     """
@@ -331,7 +346,10 @@ def analysis_info(
 def app_info(
     category: Annotated[
         AppCategories,
-        Option(help="Category to get test info for. Default is all categories."),
+        Option(
+            help="Category to get test info for. Default is all categories.",
+            case_sensitive=False,
+        ),
     ] = "*",
 ):
     """

--- a/ml_peg/cli/cli.py
+++ b/ml_peg/cli/cli.py
@@ -282,7 +282,9 @@ info_app = Typer(
 app.add_typer(info_app, help="Get info for calculations, analysis, and apps.")
 
 
-@info_app.command(name="calc", help="Get categories info")
+@info_app.command(
+    name="calc", help="List categories and tests available for calculations"
+)
 def calc_info(
     category: Annotated[
         CalcCategories,
@@ -311,7 +313,9 @@ def calc_info(
     print(f"Tests: {', '.join(get_tests(CALCS_ROOT, 'calc', category))}")
 
 
-@info_app.command(name="analysis", help="Get analysis info")
+@info_app.command(
+    name="analysis", help="List categories and tests available for analysis"
+)
 def analysis_info(
     category: Annotated[
         AnalysisCategories,
@@ -342,7 +346,9 @@ def analysis_info(
     print(f"Tests: {', '.join(get_tests(ANALYSIS_ROOT, 'analyse', category))}")
 
 
-@info_app.command(name="app", help="Get app info")
+@info_app.command(
+    name="app", help="List categories and tests available for application"
+)
 def app_info(
     category: Annotated[
         AppCategories,
@@ -369,6 +375,14 @@ def app_info(
             }\n"
         )
     print(f"Tests: {', '.join(get_tests(ANALYSIS_ROOT, 'analyse', category))}")
+
+
+@info_app.command(name="models", help="List models currently available")
+def models_info() -> None:
+    """Return information about current models."""
+    from ml_peg.models.get_models import get_model_names
+
+    print(f"Available models: {', '.join(get_model_names())}")
 
 
 @app.command(name="download", help="Download data from S3 bucket")


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Adds summary information for calculations, analysis, and applications.

Since, for example, we can have a data-only test with no calculation, each of these is collected separately.

Categories are presented as a set of case-insensitive choices, enabling autocomplete when using the CLI. We could do the same for tests, but this would make the help incredibly long.

I have also added a new `info` command, with a set of sub-commands to list the available categories and tests (including tests in a specific category), and the current models too.

We may want to extend this to the available data for download, but that means further work, as currently these are hidden by default.

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #137

## Testing

Tested commands locally.