### PR TITLE
Remove mean position during LNCI16

### DIFF
--- a/ml_peg/calcs/supramolecular/LNCI16/calc_LNCI16.py
+++ b/ml_peg/calcs/supramolecular/LNCI16/calc_LNCI16.py
@@ -9,6 +9,7 @@ from ase.calculators.calculator import Calculator
 from ase.io import read, write
 import mlipx
 from mlipx.abc import NodeWithCalculator
+import numpy as np
 from tqdm import tqdm
 import zntrack
 
@@ -147,6 +148,10 @@ class LNCI16Benchmark(zntrack.Node):
         guest_atoms.info.update(
             {"charge": guest_charge, "system": system_name, "spin": 1}
         )
+
+        complex_atoms.positions -= np.mean(complex_atoms.positions, axis=0)
+        host_atoms.positions -= np.mean(host_atoms.positions, axis=0)
+        guest_atoms.positions -= np.mean(guest_atoms.positions, axis=0)
 
         return {
             "complex": complex_atoms,

--- a/ml_peg/calcs/supramolecular/LNCI16/calc_LNCI16.py
+++ b/ml_peg/calcs/supramolecular/LNCI16/calc_LNCI16.py
@@ -150,6 +150,10 @@ class LNCI16Benchmark(zntrack.Node):
             {"charge": guest_charge, "system": system_name, "spin": 1}
         )
 
+        complex_atoms.positions -= np.mean(complex_atoms.positions, axis=0)
+        host_atoms.positions -= np.mean(host_atoms.positions, axis=0)
+        guest_atoms.positions -= np.mean(guest_atoms.positions, axis=0)
+
         return {
             "complex": complex_atoms,
             "host": host_atoms,


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Removes mean positions of atoms for LNCI16, which is currently necessary to run high precision with mace-polar-1-l without memory issues on most devices, and increases the speed considerably too.

## Testing

Tested on a 32 core EPYC 7502P. Still unable to run locally.

Further testing should be done to confirm other models are unchanged, but this didn't affect `mace-polar-1-m`.
