### PR TITLE
⚡ Bolt: Optimize load_framework_registry with lru_cache

### DIFF
--- a/ml_peg/app/utils/utils.py
+++ b/ml_peg/app/utils/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, Sequence
+import copy
 from functools import lru_cache
 import json
 from pathlib import Path
@@ -891,9 +892,10 @@ def normalize_framework_id(framework_id: str) -> str:
     return cleaned
 
 
-def load_framework_registry() -> dict[str, FrameworkEntry]:
+@lru_cache(maxsize=1)
+def _load_framework_registry() -> dict[str, FrameworkEntry]:
     """
-    Load framework badge metadata from ``frameworks.yml``.
+    Load framework badge metadata from ``frameworks.yml`` (cached).
 
     Returns
     -------
@@ -945,6 +947,18 @@ def load_framework_registry() -> dict[str, FrameworkEntry]:
         registry[normalized_id] = registry_entry
 
     return registry
+
+
+def load_framework_registry() -> dict[str, FrameworkEntry]:
+    """
+    Load framework badge metadata from ``frameworks.yml``.
+
+    Returns
+    -------
+    dict[str, FrameworkEntry]
+        Mapping of framework IDs to display configuration.
+    """
+    return copy.deepcopy(_load_framework_registry())
 
 
 def get_framework_config(framework_id: str) -> FrameworkEntry:


### PR DESCRIPTION
💡 **What**: Added an `lru_cache` to `_load_framework_registry` and exposed a safe `copy.deepcopy()` via the original `load_framework_registry` function.

🎯 **Why**: `load_framework_registry()` performs expensive file I/O and YAML parsing every time it is called. `get_framework_config()` calls it repeatedly when rendering framework badges on the frontend. Caching the file reading drastically reduces repeated read times while retaining `copy.deepcopy` preserves safe immutability.

📊 **Impact**: Time to call `get_framework_config()` 100 times reduced from 0.119s to 0.003s (a roughly 40x speedup in parsing overhead).

🔬 **Measurement**: Verified using `uv run python3 -c "import timeit; setup = 'from ml_peg.app.utils.utils import get_framework_config'; code='get_framework_config(\"ml_peg\")'; print(timeit.timeit(code, setup=setup, number=100))"` before and after changes. All pytest suites pass and no linting errors are present.

---
*PR created automatically by Jules for task [9748296984437581739](https://jules.google.com/task/9748296984437581739) started by @alinelena*