### PR TITLE
Fix CLI printing for Python<3.12

### DIFF
--- a/ml_peg/cli/cli.py
+++ b/ml_peg/cli/cli.py
@@ -310,11 +310,11 @@ def list_calcs(
     """
     if category == "*":
         print(
-            f"Categories: {
-                ', '.join(
-                    category for category in get_args(CalcCategories) if category != '*'
+            f"""Categories: {
+                ", ".join(
+                    category for category in get_args(CalcCategories) if category != "*"
                 )
-            }\n"
+            }\n"""
         )
     print(f"Tests: {', '.join(get_tests(CALCS_ROOT, 'calc', category))}")
 
@@ -341,13 +341,13 @@ def list_analysis(
     """
     if category == "*":
         print(
-            f"Categories: {
-                ', '.join(
+            f""""Categories: {
+                ", ".join(
                     category
                     for category in get_args(AnalysisCategories)
-                    if category != '*'
+                    if category != "*"
                 )
-            }\n"
+            }\n"""
         )
     print(f"Tests: {', '.join(get_tests(ANALYSIS_ROOT, 'analyse', category))}")
 
@@ -374,11 +374,11 @@ def list_apps(
     """
     if category == "*":
         print(
-            f"Categories: {
-                ', '.join(
-                    category for category in get_args(AppCategories) if category != '*'
+            f"""Categories: {
+                ", ".join(
+                    category for category in get_args(AppCategories) if category != "*"
                 )
-            }\n"
+            }\n"""
         )
     print(f"Tests: {', '.join(get_tests(ANALYSIS_ROOT, 'analyse', category))}")
 


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Apparently newlines are not supported until 3.12 with string literals, causing CLI errors in Python 3.10/3.11, unless triple quotes are used, so this adds them in.

```
Traceback (most recent call last):
  File "/Users/elliottkasoar/Documents/PSDI/ml-peg/.venv/bin/ml_peg", line 4, in <module>
    from ml_peg.cli.cli import app
  File "/Users/elliottkasoar/Documents/PSDI/ml-peg/ml_peg/cli/cli.py", line 313
    f"Categories: {
    ^
SyntaxError: unterminated string literal (detected at line 313)
```

## Testing

Tested locally on Python 3.10 and 3.12
