### PR TITLE
Add models file input option

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -47,7 +47,9 @@ def pytest_configure(config):
 
     # Set current models from CLI input
     models.current_models = config.getoption("--models")
-    models.models_file = config.getoption("--models-file")
+    model_file = config.getoption("--models-file")
+    if model_file:
+        models.models_file = model_file
 
 
 def pytest_collection_modifyitems(config, items):

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import pytest
 
-from ml_peg.models import models
+from ml_peg import models
 
 
 def pytest_addoption(parser):

--- a/conftest.py
+++ b/conftest.py
@@ -31,6 +31,12 @@ def pytest_addoption(parser):
         default=None,
         help="MLIPs, in comma-separated list. Default is all models",
     )
+    parser.addoption(
+        "--models-file",
+        action="store",
+        default=None,
+        help="Filepath to model definitions. Default models.yml in models directory.",
+    )
 
 
 def pytest_configure(config):
@@ -41,6 +47,7 @@ def pytest_configure(config):
 
     # Set current models from CLI input
     models.current_models = config.getoption("--models")
+    models.models_file = config.getoption("--models-file")
 
 
 def pytest_collection_modifyitems(config, items):

--- a/docs/source/developer_guide/add_benchmarks.rst
+++ b/docs/source/developer_guide/add_benchmarks.rst
@@ -109,7 +109,7 @@ the same calculation is run for each model name-model pair:
 .. code-block:: python3
 
     from ml_peg.models.get_models import load_models
-    from ml_peg.models.models import current_models
+    from ml_peg.models import current_models
 
     MODELS = load_models(current_models)
     DATA_PATH = Path(__file__).parent / "data"
@@ -350,7 +350,7 @@ CLI (``ml_peg analyse``), a subset can be used using the ``--models`` option.
     from ml_peg.app import APP_ROOT
     from ml_peg.calcs import CALCS_ROOT
     from ml_peg.models.get_models import get_model_names
-    from ml_peg.models.models import current_models
+    from ml_peg.models import current_models
 
     MODELS = get_model_names(current_models)
     CALC_PATH = CALCS_ROOT / [category] / [benchmark_name] / "outputs"

--- a/ml_peg/analysis/bulk_crystal/elasticity/analyse_elasticity.py
+++ b/ml_peg/analysis/bulk_crystal/elasticity/analyse_elasticity.py
@@ -26,8 +26,8 @@ from ml_peg.analysis.utils.utils import (
 from ml_peg.app import APP_ROOT
 from ml_peg.app.utils.plot_helpers import build_violin_distribution
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "bulk_crystal" / "elasticity" / "outputs"

--- a/ml_peg/analysis/bulk_crystal/high_pressure_relaxation/analyse_high_pressure_relaxation.py
+++ b/ml_peg/analysis/bulk_crystal/high_pressure_relaxation/analyse_high_pressure_relaxation.py
@@ -19,8 +19,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "bulk_crystal" / "high_pressure_relaxation" / "outputs"

--- a/ml_peg/analysis/bulk_crystal/lattice_constants/analyse_lattice_constants.py
+++ b/ml_peg/analysis/bulk_crystal/lattice_constants/analyse_lattice_constants.py
@@ -12,8 +12,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "bulk_crystal" / "lattice_constants" / "outputs"

--- a/ml_peg/analysis/bulk_crystal/phonons/analyse_phonons.py
+++ b/ml_peg/analysis/bulk_crystal/phonons/analyse_phonons.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.decorators import build_table, cell_to_scatter
 from ml_peg.analysis.utils.utils import load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "bulk_crystal" / "phonons" / "outputs"

--- a/ml_peg/analysis/conformers/37Conf8/analyse_37Conf8.py
+++ b/ml_peg/analysis/conformers/37Conf8/analyse_37Conf8.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/conformers/ACONFL/analyse_ACONFL.py
+++ b/ml_peg/analysis/conformers/ACONFL/analyse_ACONFL.py
@@ -23,8 +23,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/conformers/DipCONFS/analyse_DipCONFS.py
+++ b/ml_peg/analysis/conformers/DipCONFS/analyse_DipCONFS.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/conformers/Glucose205/analyse_Glucose205.py
+++ b/ml_peg/analysis/conformers/Glucose205/analyse_Glucose205.py
@@ -22,8 +22,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/conformers/MPCONF196/analyse_MPCONF196.py
+++ b/ml_peg/analysis/conformers/MPCONF196/analyse_MPCONF196.py
@@ -21,8 +21,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/conformers/Maltose222/analyse_Maltose222.py
+++ b/ml_peg/analysis/conformers/Maltose222/analyse_Maltose222.py
@@ -22,8 +22,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/conformers/OpenFF_Tors/analyse_OpenFF_Tors.py
+++ b/ml_peg/analysis/conformers/OpenFF_Tors/analyse_OpenFF_Tors.py
@@ -21,8 +21,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/conformers/UpU46/analyse_UpU46.py
+++ b/ml_peg/analysis/conformers/UpU46/analyse_UpU46.py
@@ -22,8 +22,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/conformers/solvMPCONF196/analyse_solvMPCONF196.py
+++ b/ml_peg/analysis/conformers/solvMPCONF196/analyse_solvMPCONF196.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/defect/Defectstab/analyse_Defectstab.py
+++ b/ml_peg/analysis/defect/Defectstab/analyse_Defectstab.py
@@ -13,8 +13,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import load_metrics_config, rmse
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "defect" / "Defectstab" / "outputs"

--- a/ml_peg/analysis/defect/Relastab/analyse_Relastab.py
+++ b/ml_peg/analysis/defect/Relastab/analyse_Relastab.py
@@ -14,8 +14,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "defect" / "Relastab" / "outputs"

--- a/ml_peg/analysis/lanthanides/isomer_complexes/analyse_isomer_complexes.py
+++ b/ml_peg/analysis/lanthanides/isomer_complexes/analyse_isomer_complexes.py
@@ -12,8 +12,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "lanthanides" / "isomer_complexes" / "outputs"

--- a/ml_peg/analysis/molecular/BMIMCl_RDF/analyse_BMIMCl_RDF.py
+++ b/ml_peg/analysis/molecular/BMIMCl_RDF/analyse_BMIMCl_RDF.py
@@ -15,8 +15,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_scatter
 from ml_peg.analysis.utils.utils import load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "molecular" / "BMIMCl_RDF" / "outputs"

--- a/ml_peg/analysis/molecular/GMTKN55/analyse_GMTKN55.py
+++ b/ml_peg/analysis/molecular/GMTKN55/analyse_GMTKN55.py
@@ -14,8 +14,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import build_dispersion_name_map, load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular/Wiggle150/analyse_Wiggle150.py
+++ b/ml_peg/analysis/molecular/Wiggle150/analyse_Wiggle150.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_crystal/CPOSS209/analyse_CPOSS209.py
+++ b/ml_peg/analysis/molecular_crystal/CPOSS209/analyse_CPOSS209.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_crystal/DMC_ICE13/analyse_DMC_ICE13.py
+++ b/ml_peg/analysis/molecular_crystal/DMC_ICE13/analyse_DMC_ICE13.py
@@ -15,8 +15,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_crystal/X23/analyse_X23.py
+++ b/ml_peg/analysis/molecular_crystal/X23/analyse_X23.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_dynamics/liquid_densities/analyse_liquid_densities.py
+++ b/ml_peg/analysis/molecular_dynamics/liquid_densities/analyse_liquid_densities.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 D3_MODEL_NAMES = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_dynamics/water_density/analyse_water_density.py
+++ b/ml_peg/analysis/molecular_dynamics/water_density/analyse_water_density.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 D3_MODEL_NAMES = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_reactions/BH2O_36/analyse_BH2O_36.py
+++ b/ml_peg/analysis/molecular_reactions/BH2O_36/analyse_BH2O_36.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_reactions/BH9/analyse_BH9.py
+++ b/ml_peg/analysis/molecular_reactions/BH9/analyse_BH9.py
@@ -21,8 +21,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_reactions/CYCLO70/analyse_CYCLO70.py
+++ b/ml_peg/analysis/molecular_reactions/CYCLO70/analyse_CYCLO70.py
@@ -24,8 +24,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_reactions/Criegee22/analyse_Criegee22.py
+++ b/ml_peg/analysis/molecular_reactions/Criegee22/analyse_Criegee22.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/molecular_reactions/RDB7/analyse_RDB7.py
+++ b/ml_peg/analysis/molecular_reactions/RDB7/analyse_RDB7.py
@@ -26,8 +26,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/nebs/li_diffusion/analyse_li_diffusion.py
+++ b/ml_peg/analysis/nebs/li_diffusion/analyse_li_diffusion.py
@@ -12,8 +12,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_scatter
 from ml_peg.analysis.utils.utils import load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "nebs" / "li_diffusion" / "outputs"

--- a/ml_peg/analysis/nebs/si_defects/analyse_si_defects.py
+++ b/ml_peg/analysis/nebs/si_defects/analyse_si_defects.py
@@ -15,8 +15,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_scatter
 from ml_peg.analysis.utils.utils import load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 

--- a/ml_peg/analysis/non_covalent_interactions/IONPI19/analyse_IONPI19.py
+++ b/ml_peg/analysis/non_covalent_interactions/IONPI19/analyse_IONPI19.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/non_covalent_interactions/NCIA_D1200/analyse_NCIA_D1200.py
+++ b/ml_peg/analysis/non_covalent_interactions/NCIA_D1200/analyse_NCIA_D1200.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/non_covalent_interactions/NCIA_D442x10/analyse_NCIA_D442x10.py
+++ b/ml_peg/analysis/non_covalent_interactions/NCIA_D442x10/analyse_NCIA_D442x10.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/non_covalent_interactions/NCIA_HB300SPXx10/analyse_NCIA_HB300SPXx10.py
+++ b/ml_peg/analysis/non_covalent_interactions/NCIA_HB300SPXx10/analyse_NCIA_HB300SPXx10.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/non_covalent_interactions/NCIA_HB375x10/analyse_NCIA_HB375x10.py
+++ b/ml_peg/analysis/non_covalent_interactions/NCIA_HB375x10/analyse_NCIA_HB375x10.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/non_covalent_interactions/NCIA_IHB100x10/analyse_NCIA_IHB100x10.py
+++ b/ml_peg/analysis/non_covalent_interactions/NCIA_IHB100x10/analyse_NCIA_IHB100x10.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/non_covalent_interactions/NCIA_R739x5/analyse_NCIA_R739x5.py
+++ b/ml_peg/analysis/non_covalent_interactions/NCIA_R739x5/analyse_NCIA_R739x5.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/non_covalent_interactions/NCIA_SH250x10/analyse_NCIA_SH250x10.py
+++ b/ml_peg/analysis/non_covalent_interactions/NCIA_SH250x10/analyse_NCIA_SH250x10.py
@@ -20,8 +20,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/non_covalent_interactions/QUID/analyse_QUID.py
+++ b/ml_peg/analysis/non_covalent_interactions/QUID/analyse_QUID.py
@@ -23,8 +23,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/physicality/diatomics/analyse_diatomics.py
+++ b/ml_peg/analysis/physicality/diatomics/analyse_diatomics.py
@@ -13,8 +13,8 @@ from ml_peg.analysis.utils.decorators import build_table, periodic_curve_gallery
 from ml_peg.analysis.utils.utils import load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "physicality" / "diatomics" / "outputs"

--- a/ml_peg/analysis/physicality/extensivity/analyse_extensivity.py
+++ b/ml_peg/analysis/physicality/extensivity/analyse_extensivity.py
@@ -11,8 +11,8 @@ from ml_peg.analysis.utils.decorators import build_table
 from ml_peg.analysis.utils.utils import load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "physicality" / "extensivity" / "outputs"

--- a/ml_peg/analysis/physicality/locality/analyse_locality.py
+++ b/ml_peg/analysis/physicality/locality/analyse_locality.py
@@ -12,8 +12,8 @@ from ml_peg.analysis.utils.decorators import build_table
 from ml_peg.analysis.utils.utils import load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "physicality" / "locality" / "outputs"

--- a/ml_peg/analysis/physicality/oxidation_states/analyse_oxidation_states.py
+++ b/ml_peg/analysis/physicality/oxidation_states/analyse_oxidation_states.py
@@ -11,8 +11,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_scatter
 from ml_peg.analysis.utils.utils import load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 

--- a/ml_peg/analysis/supramolecular/LNCI16/analyse_LNCI16.py
+++ b/ml_peg/analysis/supramolecular/LNCI16/analyse_LNCI16.py
@@ -11,8 +11,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "supramolecular" / "LNCI16" / "outputs"

--- a/ml_peg/analysis/supramolecular/PLA15/analyse_PLA15.py
+++ b/ml_peg/analysis/supramolecular/PLA15/analyse_PLA15.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/supramolecular/PLF547/analyse_PLF547.py
+++ b/ml_peg/analysis/supramolecular/PLF547/analyse_PLF547.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/supramolecular/S30L/analyse_S30L.py
+++ b/ml_peg/analysis/supramolecular/S30L/analyse_S30L.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/surfaces/OC157/analyse_OC157.py
+++ b/ml_peg/analysis/surfaces/OC157/analyse_OC157.py
@@ -16,8 +16,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/surfaces/S24/analyse_S24.py
+++ b/ml_peg/analysis/surfaces/S24/analyse_S24.py
@@ -15,8 +15,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/surfaces/SBH17/analyse_SBH17.py
+++ b/ml_peg/analysis/surfaces/SBH17/analyse_SBH17.py
@@ -15,8 +15,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 D3_MODEL_NAMES = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
@@ -11,8 +11,8 @@ from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "surfaces" / "elemental_slab_oxygen_adsorption" / "outputs"

--- a/ml_peg/analysis/surfaces/graphene_wetting_under_strain/analyse_graphene_wetting_under_strain.py
+++ b/ml_peg/analysis/surfaces/graphene_wetting_under_strain/analyse_graphene_wetting_under_strain.py
@@ -18,8 +18,8 @@ from ml_peg.analysis.utils.decorators import build_table
 from ml_peg.analysis.utils.utils import load_metrics_config, mae
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 CALC_PATH = CALCS_ROOT / "surfaces" / "graphene_wetting_under_strain" / "outputs"

--- a/ml_peg/analysis/tm_complexes/3dTMV/analyse_3dTMV.py
+++ b/ml_peg/analysis/tm_complexes/3dTMV/analyse_3dTMV.py
@@ -19,8 +19,8 @@ from ml_peg.analysis.utils.utils import (
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/analysis/utils/analyse_gscdb138.py
+++ b/ml_peg/analysis/utils/analyse_gscdb138.py
@@ -10,8 +10,8 @@ from ase.io import read, write
 from ml_peg.analysis.utils.decorators import build_table, plot_parity
 from ml_peg.analysis.utils.utils import build_dispersion_name_map, mae
 from ml_peg.app.utils.utils import Thresholds
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)

--- a/ml_peg/app/build_app.py
+++ b/ml_peg/app/build_app.py
@@ -32,8 +32,8 @@ from ml_peg.app.utils.utils import (
     load_model_registry_configs,
     sig_fig_format,
 )
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/bulk_crystal/elasticity/app_elasticity.py
+++ b/ml_peg/app/bulk_crystal/elasticity/app_elasticity.py
@@ -12,8 +12,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/bulk_crystal/high_pressure_relaxation/app_high_pressure_relaxation.py
+++ b/ml_peg/app/bulk_crystal/high_pressure_relaxation/app_high_pressure_relaxation.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/bulk_crystal/lattice_constants/app_lattice_constants.py
+++ b/ml_peg/app/bulk_crystal/lattice_constants/app_lattice_constants.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_column, struct_from_scatter
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/conformers/37Conf8/app_37Conf8.py
+++ b/ml_peg/app/conformers/37Conf8/app_37Conf8.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "37Conf8"

--- a/ml_peg/app/conformers/ACONFL/app_ACONFL.py
+++ b/ml_peg/app/conformers/ACONFL/app_ACONFL.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "ACONFL"

--- a/ml_peg/app/conformers/DipCONFS/app_DipCONFS.py
+++ b/ml_peg/app/conformers/DipCONFS/app_DipCONFS.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "DipCONFS"

--- a/ml_peg/app/conformers/Glucose205/app_Glucose205.py
+++ b/ml_peg/app/conformers/Glucose205/app_Glucose205.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "Glucose205"

--- a/ml_peg/app/conformers/MPCONF196/app_MPCONF196.py
+++ b/ml_peg/app/conformers/MPCONF196/app_MPCONF196.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "MPCONF196"

--- a/ml_peg/app/conformers/Maltose222/app_Maltose222.py
+++ b/ml_peg/app/conformers/Maltose222/app_Maltose222.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "Maltose222"

--- a/ml_peg/app/conformers/OpenFF_Tors/app_OpenFF_Tors.py
+++ b/ml_peg/app/conformers/OpenFF_Tors/app_OpenFF_Tors.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "OpenFF-Tors"

--- a/ml_peg/app/conformers/UpU46/app_UpU46.py
+++ b/ml_peg/app/conformers/UpU46/app_UpU46.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "UpU46"

--- a/ml_peg/app/conformers/solvMPCONF196/app_solvMPCONF196.py
+++ b/ml_peg/app/conformers/solvMPCONF196/app_solvMPCONF196.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "solvMPCONF196"

--- a/ml_peg/app/defect/Defectstab/app_Defectstab.py
+++ b/ml_peg/app/defect/Defectstab/app_Defectstab.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/defect/Relastab/app_Relastab.py
+++ b/ml_peg/app/defect/Relastab/app_Relastab.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/lanthanides/isomer_complexes/app_isomer_complexes.py
+++ b/ml_peg/app/lanthanides/isomer_complexes/app_isomer_complexes.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_column, struct_from_scatter
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "Lanthanide Isomer Complexes"

--- a/ml_peg/app/molecular/GMTKN55/app_GMTKN55.py
+++ b/ml_peg/app/molecular/GMTKN55/app_GMTKN55.py
@@ -11,8 +11,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_column, struct_from_scatter
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/molecular/Wiggle150/app_Wiggle150.py
+++ b/ml_peg/app/molecular/Wiggle150/app_Wiggle150.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/molecular_crystal/CPOSS209/app_CPOSS209.py
+++ b/ml_peg/app/molecular_crystal/CPOSS209/app_CPOSS209.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/molecular_crystal/DMC_ICE13/app_DMC_ICE13.py
+++ b/ml_peg/app/molecular_crystal/DMC_ICE13/app_DMC_ICE13.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/molecular_crystal/X23/app_X23.py
+++ b/ml_peg/app/molecular_crystal/X23/app_X23.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/molecular_dynamics/liquid_densities/app_liquid_densities.py
+++ b/ml_peg/app/molecular_dynamics/liquid_densities/app_liquid_densities.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "Liquid Densities"

--- a/ml_peg/app/molecular_dynamics/water_density/app_water_density.py
+++ b/ml_peg/app/molecular_dynamics/water_density/app_water_density.py
@@ -11,8 +11,8 @@ from ml_peg.app.utils.build_callbacks import (
     plot_from_table_column,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "Water Density"

--- a/ml_peg/app/molecular_reactions/BH2O_36/app_BH2O_36.py
+++ b/ml_peg/app/molecular_reactions/BH2O_36/app_BH2O_36.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "BH2O-36"

--- a/ml_peg/app/molecular_reactions/BH9/app_BH9.py
+++ b/ml_peg/app/molecular_reactions/BH9/app_BH9.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "BH9"

--- a/ml_peg/app/molecular_reactions/CYCLO70/app_CYCLO70.py
+++ b/ml_peg/app/molecular_reactions/CYCLO70/app_CYCLO70.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "CYCLO70"

--- a/ml_peg/app/molecular_reactions/Criegee22/app_Criegee22.py
+++ b/ml_peg/app/molecular_reactions/Criegee22/app_Criegee22.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "Criegee22"

--- a/ml_peg/app/molecular_reactions/RDB7/app_RDB7.py
+++ b/ml_peg/app/molecular_reactions/RDB7/app_RDB7.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "RDB7"

--- a/ml_peg/app/nebs/li_diffusion/app_li_diffusion.py
+++ b/ml_peg/app/nebs/li_diffusion/app_li_diffusion.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/nebs/si_defects/app_si_defects.py
+++ b/ml_peg/app/nebs/si_defects/app_si_defects.py
@@ -11,8 +11,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 

--- a/ml_peg/app/non_covalent_interactions/IONPI19/app_IONPI19.py
+++ b/ml_peg/app/non_covalent_interactions/IONPI19/app_IONPI19.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "IONPI19"

--- a/ml_peg/app/non_covalent_interactions/NCIA_D1200/app_NCIA_D1200.py
+++ b/ml_peg/app/non_covalent_interactions/NCIA_D1200/app_NCIA_D1200.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "NCIA D1200"

--- a/ml_peg/app/non_covalent_interactions/NCIA_D442x10/app_NCIA_D442x10.py
+++ b/ml_peg/app/non_covalent_interactions/NCIA_D442x10/app_NCIA_D442x10.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "NCIA D442x10"

--- a/ml_peg/app/non_covalent_interactions/NCIA_HB300SPXx10/app_NCIA_HB300SPXx10.py
+++ b/ml_peg/app/non_covalent_interactions/NCIA_HB300SPXx10/app_NCIA_HB300SPXx10.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "NCIA HB300SPXx10"

--- a/ml_peg/app/non_covalent_interactions/NCIA_HB375x10/app_NCIA_HB375x10.py
+++ b/ml_peg/app/non_covalent_interactions/NCIA_HB375x10/app_NCIA_HB375x10.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "NCIA HB375x10"

--- a/ml_peg/app/non_covalent_interactions/NCIA_IHB100x10/app_NCIA_IHB100x10.py
+++ b/ml_peg/app/non_covalent_interactions/NCIA_IHB100x10/app_NCIA_IHB100x10.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "NCIA IHB100x10"

--- a/ml_peg/app/non_covalent_interactions/NCIA_R739x5/app_NCIA_R739x5.py
+++ b/ml_peg/app/non_covalent_interactions/NCIA_R739x5/app_NCIA_R739x5.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "NCIA R739x5"

--- a/ml_peg/app/non_covalent_interactions/NCIA_SH250x10/app_NCIA_SH250x10.py
+++ b/ml_peg/app/non_covalent_interactions/NCIA_SH250x10/app_NCIA_SH250x10.py
@@ -9,8 +9,8 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "NCIA SH250x10"

--- a/ml_peg/app/non_covalent_interactions/QUID/app_QUID.py
+++ b/ml_peg/app/non_covalent_interactions/QUID/app_QUID.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "QUID"

--- a/ml_peg/app/physicality/diatomics/app_diatomics.py
+++ b/ml_peg/app/physicality/diatomics/app_diatomics.py
@@ -9,8 +9,8 @@ from dash.html import Div, Label
 from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import register_image_gallery_callbacks
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/physicality/extensivity/app_extensivity.py
+++ b/ml_peg/app/physicality/extensivity/app_extensivity.py
@@ -8,8 +8,8 @@ from dash.html import Div
 from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import struct_from_table
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/physicality/locality/app_locality.py
+++ b/ml_peg/app/physicality/locality/app_locality.py
@@ -8,8 +8,8 @@ from dash.html import Div
 from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import struct_from_table
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/physicality/oxidation_states/app_oxidation_states.py
+++ b/ml_peg/app/physicality/oxidation_states/app_oxidation_states.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
 )
 from ml_peg.app.utils.load import read_plot
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 

--- a/ml_peg/app/supramolecular/LNCI16/app_LNCI16.py
+++ b/ml_peg/app/supramolecular/LNCI16/app_LNCI16.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/supramolecular/PLA15/app_PLA15.py
+++ b/ml_peg/app/supramolecular/PLA15/app_PLA15.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 

--- a/ml_peg/app/supramolecular/PLF547/app_PLF547.py
+++ b/ml_peg/app/supramolecular/PLF547/app_PLF547.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/supramolecular/S30L/app_S30L.py
+++ b/ml_peg/app/supramolecular/S30L/app_S30L.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/surfaces/OC157/app_OC157.py
+++ b/ml_peg/app/surfaces/OC157/app_OC157.py
@@ -13,8 +13,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/surfaces/S24/app_S24.py
+++ b/ml_peg/app/surfaces/S24/app_S24.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/surfaces/SBH17/app_SBH17.py
+++ b/ml_peg/app/surfaces/SBH17/app_SBH17.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/surfaces/elemental_slab_oxygen_adsorption/app_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/app/surfaces/elemental_slab_oxygen_adsorption/app_elemental_slab_oxygen_adsorption.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/surfaces/graphene_wetting_under_strain/app_graphene_wetting_under_strain.py
+++ b/ml_peg/app/surfaces/graphene_wetting_under_strain/app_graphene_wetting_under_strain.py
@@ -14,8 +14,8 @@ from ml_peg.app.utils.build_callbacks import (
 )
 from ml_peg.app.utils.load import read_plot
 from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 # Get all models
 MODELS = get_model_names(current_models)

--- a/ml_peg/app/tm_complexes/3dTMV/app_3dTMV.py
+++ b/ml_peg/app/tm_complexes/3dTMV/app_3dTMV.py
@@ -12,8 +12,8 @@ from ml_peg.app.utils.build_callbacks import (
     struct_from_scatter,
 )
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 BENCHMARK_NAME = "3dTMV"

--- a/ml_peg/app/utils/gscdb138.py
+++ b/ml_peg/app/utils/gscdb138.py
@@ -9,8 +9,8 @@ from dash.html import Div
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_column, struct_from_scatter
 from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
-from ml_peg.models.models import current_models
 
 MODELS = get_model_names(current_models)
 

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -17,8 +17,8 @@ from pymatgen.io.ase import AseAtomsAdaptor
 from pymatgen.symmetry.analyzer import SpacegroupAnalyzer
 import pytest
 
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 OUT_PATH = Path(__file__).parent / "outputs"

--- a/ml_peg/calcs/bulk_crystal/high_pressure_relaxation/calc_high_pressure_relaxation.py
+++ b/ml_peg/calcs/bulk_crystal/high_pressure_relaxation/calc_high_pressure_relaxation.py
@@ -21,8 +21,8 @@ from pymatgen.io.ase import AseAtomsAdaptor
 import pytest
 from tqdm import tqdm
 
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/bulk_crystal/lattice_constants/calc_lattice_constants.py
+++ b/ml_peg/calcs/bulk_crystal/lattice_constants/calc_lattice_constants.py
@@ -13,8 +13,8 @@ from janus_core.calculations.geom_opt import GeomOpt
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/37Conf8/calc_37Conf8.py
+++ b/ml_peg/calcs/conformers/37Conf8/calc_37Conf8.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/ACONFL/calc_ACONFL.py
+++ b/ml_peg/calcs/conformers/ACONFL/calc_ACONFL.py
@@ -18,8 +18,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/DipCONFS/calc_DipCONFS.py
+++ b/ml_peg/calcs/conformers/DipCONFS/calc_DipCONFS.py
@@ -21,8 +21,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/Glucose205/calc_Glucose205.py
+++ b/ml_peg/calcs/conformers/Glucose205/calc_Glucose205.py
@@ -18,8 +18,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -18,8 +18,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/Maltose222/calc_Maltose222.py
+++ b/ml_peg/calcs/conformers/Maltose222/calc_Maltose222.py
@@ -18,8 +18,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/OpenFF_Tors/calc_OpenFF_Tors.py
+++ b/ml_peg/calcs/conformers/OpenFF_Tors/calc_OpenFF_Tors.py
@@ -19,8 +19,8 @@ from rdkit import Chem
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/UpU46/calc_UpU46.py
+++ b/ml_peg/calcs/conformers/UpU46/calc_UpU46.py
@@ -17,8 +17,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -18,8 +18,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/defect/Defectstab/calc_Defectstab.py
+++ b/ml_peg/calcs/defect/Defectstab/calc_Defectstab.py
@@ -9,8 +9,8 @@ from ase.io import read, write
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/defect/Relastab/calc_Relastab.py
+++ b/ml_peg/calcs/defect/Relastab/calc_Relastab.py
@@ -9,8 +9,8 @@ from ase.io import read, write
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/electric_field/GSCDB138_field/calc_GSCDB138_field.py
+++ b/ml_peg/calcs/electric_field/GSCDB138_field/calc_GSCDB138_field.py
@@ -12,8 +12,8 @@ from typing import Any
 import pytest
 
 from ml_peg.calcs.utils.gscdb138 import run_gscdb138
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/isomers/GSCDB138_isomers/calc_GSCDB138_isomers.py
+++ b/ml_peg/calcs/isomers/GSCDB138_isomers/calc_GSCDB138_isomers.py
@@ -12,8 +12,8 @@ from typing import Any
 import pytest
 
 from ml_peg.calcs.utils.gscdb138 import run_gscdb138
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/lanthanides/isomer_complexes/calc_isomer_complexes.py
+++ b/ml_peg/calcs/lanthanides/isomer_complexes/calc_isomer_complexes.py
@@ -13,8 +13,8 @@ from tqdm import tqdm
 
 from ml_peg.calcs import CALCS_ROOT
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular/BMIMCl_RDF/calc_BMIMCl_RDF.py
+++ b/ml_peg/calcs/molecular/BMIMCl_RDF/calc_BMIMCl_RDF.py
@@ -20,8 +20,8 @@ import molify
 import pytest
 from tqdm import tqdm
 
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular/GMTKN55/calc_GMTKN55.py
+++ b/ml_peg/calcs/molecular/GMTKN55/calc_GMTKN55.py
@@ -15,8 +15,8 @@ from tqdm import tqdm
 import yaml
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular/Wiggle150/calc_Wiggle150.py
+++ b/ml_peg/calcs/molecular/Wiggle150/calc_Wiggle150.py
@@ -13,8 +13,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_crystal/CPOSS209/calc_CPOSS209.py
+++ b/ml_peg/calcs/molecular_crystal/CPOSS209/calc_CPOSS209.py
@@ -12,8 +12,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_crystal/DMC_ICE13/calc_DMC_ICE13.py
+++ b/ml_peg/calcs/molecular_crystal/DMC_ICE13/calc_DMC_ICE13.py
@@ -11,8 +11,8 @@ from ase.io import read, write
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_crystal/X23/calc_X23.py
+++ b/ml_peg/calcs/molecular_crystal/X23/calc_X23.py
@@ -12,8 +12,8 @@ import numpy as np
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_dynamics/liquid_densities/calc_liquid_densities.py
+++ b/ml_peg/calcs/molecular_dynamics/liquid_densities/calc_liquid_densities.py
@@ -18,8 +18,8 @@ from ase.md.nose_hoover_chain import IsotropicMTKNPT
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_dynamics/water_density/calc_water_density.py
+++ b/ml_peg/calcs/molecular_dynamics/water_density/calc_water_density.py
@@ -14,8 +14,8 @@ from ase.md.nose_hoover_chain import IsotropicMTKNPT
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_reactions/BH2O_36/calc_BH2O_36.py
+++ b/ml_peg/calcs/molecular_reactions/BH2O_36/calc_BH2O_36.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_reactions/BH9/calc_BH9.py
+++ b/ml_peg/calcs/molecular_reactions/BH9/calc_BH9.py
@@ -17,8 +17,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_reactions/CYCLO70/calc_CYCLO70.py
+++ b/ml_peg/calcs/molecular_reactions/CYCLO70/calc_CYCLO70.py
@@ -19,8 +19,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_reactions/Criegee22/calc_Criegee22.py
+++ b/ml_peg/calcs/molecular_reactions/Criegee22/calc_Criegee22.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_reactions/GSCDB138_barriers/calc_GSCDB138_barriers.py
+++ b/ml_peg/calcs/molecular_reactions/GSCDB138_barriers/calc_GSCDB138_barriers.py
@@ -12,8 +12,8 @@ from typing import Any
 import pytest
 
 from ml_peg.calcs.utils.gscdb138 import run_gscdb138
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/molecular_reactions/RDB7/calc_RDB7.py
+++ b/ml_peg/calcs/molecular_reactions/RDB7/calc_RDB7.py
@@ -20,8 +20,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/nebs/li_diffusion/calc_li_diffusion.py
+++ b/ml_peg/calcs/nebs/li_diffusion/calc_li_diffusion.py
@@ -10,8 +10,8 @@ from janus_core.calculations.geom_opt import GeomOpt
 from janus_core.calculations.neb import NEB
 import pytest
 
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/nebs/si_defects/calc_si_defects.py
+++ b/ml_peg/calcs/nebs/si_defects/calc_si_defects.py
@@ -14,8 +14,8 @@ import pytest
 from tqdm.auto import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/GSCDB138_NCIs/calc_GSCDB138_NCIs.py
+++ b/ml_peg/calcs/non_covalent_interactions/GSCDB138_NCIs/calc_GSCDB138_NCIs.py
@@ -12,8 +12,8 @@ from typing import Any
 import pytest
 
 from ml_peg.calcs.utils.gscdb138 import run_gscdb138
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/IONPI19/calc_IONPI19.py
+++ b/ml_peg/calcs/non_covalent_interactions/IONPI19/calc_IONPI19.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/NCIA_D1200/calc_NCIA_D1200.py
+++ b/ml_peg/calcs/non_covalent_interactions/NCIA_D1200/calc_NCIA_D1200.py
@@ -17,8 +17,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/NCIA_D442x10/calc_NCIA_D442x10.py
+++ b/ml_peg/calcs/non_covalent_interactions/NCIA_D442x10/calc_NCIA_D442x10.py
@@ -17,8 +17,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/NCIA_HB300SPXx10/calc_NCIA_HB300SPXx10.py
+++ b/ml_peg/calcs/non_covalent_interactions/NCIA_HB300SPXx10/calc_NCIA_HB300SPXx10.py
@@ -15,8 +15,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/NCIA_HB375x10/calc_NCIA_HB375x10.py
+++ b/ml_peg/calcs/non_covalent_interactions/NCIA_HB375x10/calc_NCIA_HB375x10.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/NCIA_IHB100x10/calc_NCIA_IHB100x10.py
+++ b/ml_peg/calcs/non_covalent_interactions/NCIA_IHB100x10/calc_NCIA_IHB100x10.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/NCIA_R739x5/calc_NCIA_R739x5.py
+++ b/ml_peg/calcs/non_covalent_interactions/NCIA_R739x5/calc_NCIA_R739x5.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/NCIA_SH250x10/calc_NCIA_SH250x10.py
+++ b/ml_peg/calcs/non_covalent_interactions/NCIA_SH250x10/calc_NCIA_SH250x10.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/non_covalent_interactions/QUID/calc_QUID.py
+++ b/ml_peg/calcs/non_covalent_interactions/QUID/calc_QUID.py
@@ -20,8 +20,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/physicality/diatomics/calc_diatomics.py
+++ b/ml_peg/calcs/physicality/diatomics/calc_diatomics.py
@@ -15,8 +15,8 @@ import pandas as pd
 import pytest
 from tqdm import tqdm
 
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/physicality/extensivity/calc_extensivity.py
+++ b/ml_peg/calcs/physicality/extensivity/calc_extensivity.py
@@ -11,8 +11,8 @@ from ase.build import bulk, surface
 from ase.io import write
 import pytest
 
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/physicality/locality/calc_locality.py
+++ b/ml_peg/calcs/physicality/locality/calc_locality.py
@@ -12,8 +12,8 @@ import pytest
 from rdkit import Chem
 from rdkit.Chem import AllChem
 
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/physicality/oxidation_states/calc_oxidation_states.py
+++ b/ml_peg/calcs/physicality/oxidation_states/calc_oxidation_states.py
@@ -12,8 +12,8 @@ import numpy as np
 import pytest
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/supramolecular/LNCI16/calc_LNCI16.py
+++ b/ml_peg/calcs/supramolecular/LNCI16/calc_LNCI16.py
@@ -13,8 +13,8 @@ from tqdm import tqdm
 import zntrack
 
 from ml_peg.calcs.utils.utils import chdir, download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/supramolecular/PLA15/calc_PLA15.py
+++ b/ml_peg/calcs/supramolecular/PLA15/calc_PLA15.py
@@ -10,8 +10,8 @@ import zntrack
 
 from ml_peg.calcs.supramolecular.utils.plf547_pla15_utils import run_benchmark
 from ml_peg.calcs.utils.utils import chdir
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/supramolecular/PLF547/calc_PLF547.py
+++ b/ml_peg/calcs/supramolecular/PLF547/calc_PLF547.py
@@ -10,8 +10,8 @@ import zntrack
 
 from ml_peg.calcs.supramolecular.utils.plf547_pla15_utils import run_benchmark
 from ml_peg.calcs.utils.utils import chdir
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/supramolecular/S30L/calc_S30L.py
+++ b/ml_peg/calcs/supramolecular/S30L/calc_S30L.py
@@ -14,8 +14,8 @@ from tqdm import tqdm
 import zntrack
 
 from ml_peg.calcs.utils.utils import chdir, download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/surfaces/OC157/calc_OC157.py
+++ b/ml_peg/calcs/surfaces/OC157/calc_OC157.py
@@ -14,8 +14,8 @@ from tqdm import tqdm
 import zntrack
 
 from ml_peg.calcs.utils.utils import chdir, download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/surfaces/S24/calc_S24.py
+++ b/ml_peg/calcs/surfaces/S24/calc_S24.py
@@ -14,8 +14,8 @@ from tqdm import tqdm
 import zntrack
 
 from ml_peg.calcs.utils.utils import chdir, download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/surfaces/SBH17/calc_SBH17.py
+++ b/ml_peg/calcs/surfaces/SBH17/calc_SBH17.py
@@ -12,8 +12,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/surfaces/elemental_slab_oxygen_adsorption/calc_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/calcs/surfaces/elemental_slab_oxygen_adsorption/calc_elemental_slab_oxygen_adsorption.py
@@ -14,8 +14,8 @@ from tqdm import tqdm
 import zntrack
 
 from ml_peg.calcs.utils.utils import chdir, download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/surfaces/graphene_wetting_under_strain/calc_graphene_wetting_under_strain.py
+++ b/ml_peg/calcs/surfaces/graphene_wetting_under_strain/calc_graphene_wetting_under_strain.py
@@ -11,8 +11,8 @@ from tqdm import tqdm
 import yaml
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/thermochemistry/GSCDB138_thermochemistry/calc_GSCDB138_thermochemistry.py
+++ b/ml_peg/calcs/thermochemistry/GSCDB138_thermochemistry/calc_GSCDB138_thermochemistry.py
@@ -12,8 +12,8 @@ from typing import Any
 import pytest
 
 from ml_peg.calcs.utils.gscdb138 import run_gscdb138
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/tm_complexes/3dTMV/calc_3dTMV.py
+++ b/ml_peg/calcs/tm_complexes/3dTMV/calc_3dTMV.py
@@ -16,8 +16,8 @@ import pytest
 from tqdm import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/calcs/tm_complexes/GSCDB138_tm_complexes/calc_GSCDB138_tm_complexes.py
+++ b/ml_peg/calcs/tm_complexes/GSCDB138_tm_complexes/calc_GSCDB138_tm_complexes.py
@@ -12,8 +12,8 @@ from typing import Any
 import pytest
 
 from ml_peg.calcs.utils.gscdb138 import run_gscdb138
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 MODELS = load_models(current_models)
 

--- a/ml_peg/cli/cli.py
+++ b/ml_peg/cli/cli.py
@@ -97,6 +97,15 @@ def run_dash_app(
             )
         ),
     ] = None,
+    models_file: Annotated[
+        Path | None,
+        Option(
+            help=(
+                "Path to model definitions YAML file. Default is models.yml in models "
+                "directory."
+            ),
+        ),
+    ] = None,
     category: Annotated[
         AppCategories,
         Option(
@@ -115,6 +124,8 @@ def run_dash_app(
     models
         Models to run calculations for, in comma-separated list. Default is `None`,
         corresponding to all available models.
+    models_file
+        Path to model definitions YAML file. Default is models.yml in models directory.
     category
         Category to build app for. Default is `*`, corresponding to all categories.
     port
@@ -126,6 +137,7 @@ def run_dash_app(
 
     # Overwrite current_models before it is imported elsewhere
     ml_peg_models.current_models = models
+    ml_peg_models.models_file = models_file
 
     from ml_peg.app.run_app import run_app
 
@@ -143,6 +155,15 @@ def run_calcs(
         str | None,
         Option(
             help="Comma-separated models to run calculations on. Default is all models."
+        ),
+    ] = None,
+    models_file: Annotated[
+        Path | None,
+        Option(
+            help=(
+                "Path to model definitions YAML file. Default is models.yml in models "
+                "directory."
+            ),
         ),
     ] = None,
     category: Annotated[
@@ -175,6 +196,8 @@ def run_calcs(
     models
         Models to run calculations for, in comma-separated list. Default is `None`,
         corresponding to all available models.
+    models_file
+        Path to model definitions YAML file. Default is models.yml in models directory.
     category
         Category to run calculations for. Default is `*`, corresponding to all
         categories.
@@ -210,6 +233,9 @@ def run_calcs(
     if models:
         options.extend(["--models", models])
 
+    if models_file:
+        options.extend(["--models-file", models_file])
+
     # Parse any custom options to pytest
     options.extend(ctx.args)
 
@@ -222,6 +248,15 @@ def run_analysis(
         str | None,
         Option(
             help="Comma-separated models to run analysis for. Default is all models."
+        ),
+    ] = None,
+    models_file: Annotated[
+        Path | None,
+        Option(
+            help=(
+                "Path to model definitions YAML file. Default is models.yml in models "
+                "directory."
+            ),
         ),
     ] = None,
     category: Annotated[
@@ -246,6 +281,8 @@ def run_analysis(
     models
         Models to run analysis for, in comma-separated list. Default is `None`,
         corresponding to all available models.
+    models_file
+        Path to model definitions YAML file. Default is models.yml in models directory.
     category
         Category to run analysis for. Default is `*`, corresponding to all categories.
     test
@@ -270,6 +307,9 @@ def run_analysis(
 
     if models:
         options.extend(["--models", models])
+
+    if models_file:
+        options.extend(["--models-file", models_file])
 
     pytest.main(options)
 
@@ -384,11 +424,31 @@ def list_apps(
 
 
 @list_app.command(name="models", help="List models currently available")
-def list_models() -> None:
-    """List currently available models."""
+def list_models(
+    models_file: Annotated[
+        str,
+        Option(
+            help=(
+                "Path to model definitions YAML file. Default is models.yml in models "
+                "directory."
+            ),
+        ),
+    ] = None,
+) -> None:
+    """
+    List currently available models.
+
+    Parameters
+    ----------
+    models_file
+        Path to model definitions YAML file. Default is models.yml in models directory.
+    """
     from ml_peg.models.get_models import get_model_names
 
-    print(f"Available models: {', '.join(get_model_names())}")
+    if models_file is None:
+        from ml_peg.models import models_file
+
+    print(f"Available models: {', '.join(get_model_names(filepath=models_file))}")
 
 
 @app.command(name="download", help="Download data from S3 bucket")

--- a/ml_peg/models/__init__.py
+++ b/ml_peg/models/__init__.py
@@ -5,3 +5,5 @@ from __future__ import annotations
 from pathlib import Path
 
 MODELS_ROOT = Path(__file__).parent
+current_models = None
+models_file = MODELS_ROOT / "models.yml"

--- a/ml_peg/models/get_models.py
+++ b/ml_peg/models/get_models.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from copy import deepcopy
 from functools import lru_cache
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -13,21 +14,29 @@ from ml_peg.models import MODELS_ROOT
 
 
 @lru_cache(maxsize=1)
-def _load_models_yaml() -> dict[str, Any]:
+def _load_models_yaml(
+    filepath: Path | str = MODELS_ROOT / "models.yml",
+) -> dict[str, Any]:
     """
     Load and cache models.yml to prevent repeated expensive YAML parsing.
+
+    Parameters
+    ----------
+    filepath
+        Path to YAML file with models. Default is `MODELS_ROOT / "models.yml"`.
 
     Returns
     -------
     dict[str, Any]
         Parsed models.yml registry.
     """
-    with open(MODELS_ROOT / "models.yml", encoding="utf8") as file:
+    with open(filepath, encoding="utf8") as file:
         return yaml.safe_load(file) or {}
 
 
 def load_model_configs(
     mlips: Iterable[str] | tuple[str, ...],
+    filepath: Path | str = MODELS_ROOT / "models.yml",
 ) -> tuple[dict[str, Any], dict[str, str | None]]:
     """
     Load model configurations and level of theory metadata from models.yml.
@@ -36,6 +45,8 @@ def load_model_configs(
     ----------
     mlips
         Iterable of model identifiers to load configurations for.
+    filepath
+        Path to YAML file with models. Default is `MODELS_ROOT / "models.yml"`.
 
     Returns
     -------
@@ -45,7 +56,7 @@ def load_model_configs(
         - model_levels: Dictionary mapping model names to their level of
           theory (or ``None``)
     """
-    all_models = _load_models_yaml()
+    all_models = _load_models_yaml(filepath)
 
     model_levels: dict[str, str | None] = {}
     model_configs: dict[str, Any] = {}
@@ -95,16 +106,21 @@ def get_subset(
                 ) from err
 
 
-def load_models(models: None | str | Iterable = None) -> dict[str, Any]:
+def load_models(
+    models: None | str | Iterable = None,
+    filepath: Path | str = MODELS_ROOT / "models.yml",
+) -> dict[str, Any]:
     """
     Load models for use in calculations.
 
     Parameters
     ----------
     models
-        Models to select from models.yml. If `None`, all models will be selected.
+        Models to select from `filepath`. If `None`, all models will be selected.
         If an iterable, all models with matching keys will be selected. If a string,
         this will be treated as a comma-separated list.
+    filepath
+        Path to YAML file with models. Default is `MODELS_ROOT / "models.yml"`.
 
     Returns
     -------
@@ -116,10 +132,10 @@ def load_models(models: None | str | Iterable = None) -> dict[str, Any]:
     loaded_models = {}
 
     # Load models from registry YAML: models.yml
-    all_models = _load_models_yaml()
+    all_models = _load_models_yaml(filepath)
 
     for name, cfg in get_subset(all_models, models).items():
-        print(f"Loading model from models.yml: {name}")
+        print(f"Loading model from {filepath}: {name}")
 
         match cfg["class_name"]:
             case "FAIRChemCalculator":
@@ -174,24 +190,29 @@ def load_models(models: None | str | Iterable = None) -> dict[str, Any]:
     return loaded_models
 
 
-def get_model_names(models: None | Iterable = None) -> list[str]:
+def get_model_names(
+    models: None | Iterable = None,
+    filepath: Path | str = MODELS_ROOT / "models.yml",
+) -> list[str]:
     """
     Load models names for use in analysis.
 
     Parameters
     ----------
     models
-        Models to select from models.yml. If `None`, all models will be selected.
+        Models to select from `filepath`. If `None`, all models will be selected.
         If an iterable, all models with matching keys will be selected. If a string,
         this will be treated as a comma-separated list.
+    filepath
+        Path to YAML file with models. Default is `MODELS_ROOT / "models.yml"`.
 
     Returns
     -------
     list[str]
-        Loaded model names from models.yml.
+        Loaded model names from `filepath`.
     """
     # Load models from registry YAML: models.yml
-    all_models = _load_models_yaml()
+    all_models = _load_models_yaml(filepath)
 
     model_names = []
     for name in get_subset(all_models, models):

--- a/ml_peg/models/get_models.py
+++ b/ml_peg/models/get_models.py
@@ -10,12 +10,12 @@ from typing import Any
 
 import yaml
 
-from ml_peg.models import MODELS_ROOT
+from ml_peg.models import models_file
 
 
 @lru_cache(maxsize=1)
 def _load_models_yaml(
-    filepath: Path | str = MODELS_ROOT / "models.yml",
+    filepath: Path | str | None = None,
 ) -> dict[str, Any]:
     """
     Load and cache models.yml to prevent repeated expensive YAML parsing.
@@ -23,20 +23,21 @@ def _load_models_yaml(
     Parameters
     ----------
     filepath
-        Path to YAML file with models. Default is `MODELS_ROOT / "models.yml"`.
+        Path to YAML file with models. Default is `models_file`.
 
     Returns
     -------
     dict[str, Any]
         Parsed models.yml registry.
     """
+    filepath = filepath if filepath else models_file
     with open(filepath, encoding="utf8") as file:
         return yaml.safe_load(file) or {}
 
 
 def load_model_configs(
     mlips: Iterable[str] | tuple[str, ...],
-    filepath: Path | str = MODELS_ROOT / "models.yml",
+    filepath: Path | str | None = None,
 ) -> tuple[dict[str, Any], dict[str, str | None]]:
     """
     Load model configurations and level of theory metadata from models.yml.
@@ -46,7 +47,7 @@ def load_model_configs(
     mlips
         Iterable of model identifiers to load configurations for.
     filepath
-        Path to YAML file with models. Default is `MODELS_ROOT / "models.yml"`.
+        Path to YAML file with models. Default is `models_file`.
 
     Returns
     -------
@@ -56,6 +57,7 @@ def load_model_configs(
         - model_levels: Dictionary mapping model names to their level of
           theory (or ``None``)
     """
+    filepath = filepath if filepath else models_file
     all_models = _load_models_yaml(filepath)
 
     model_levels: dict[str, str | None] = {}
@@ -108,7 +110,7 @@ def get_subset(
 
 def load_models(
     models: None | str | Iterable = None,
-    filepath: Path | str = MODELS_ROOT / "models.yml",
+    filepath: Path | str | None = None,
 ) -> dict[str, Any]:
     """
     Load models for use in calculations.
@@ -120,7 +122,7 @@ def load_models(
         If an iterable, all models with matching keys will be selected. If a string,
         this will be treated as a comma-separated list.
     filepath
-        Path to YAML file with models. Default is `MODELS_ROOT / "models.yml"`.
+        Path to YAML file with models. Default is `models_file`.
 
     Returns
     -------
@@ -131,7 +133,7 @@ def load_models(
 
     loaded_models = {}
 
-    # Load models from registry YAML: models.yml
+    filepath = filepath if filepath else models_file
     all_models = _load_models_yaml(filepath)
 
     for name, cfg in get_subset(all_models, models).items():
@@ -192,7 +194,7 @@ def load_models(
 
 def get_model_names(
     models: None | Iterable = None,
-    filepath: Path | str = MODELS_ROOT / "models.yml",
+    filepath: Path | str | None = None,
 ) -> list[str]:
     """
     Load models names for use in analysis.
@@ -204,14 +206,14 @@ def get_model_names(
         If an iterable, all models with matching keys will be selected. If a string,
         this will be treated as a comma-separated list.
     filepath
-        Path to YAML file with models. Default is `MODELS_ROOT / "models.yml"`.
+        Path to YAML file with models. Default is `models_file`.
 
     Returns
     -------
     list[str]
         Loaded model names from `filepath`.
     """
-    # Load models from registry YAML: models.yml
+    filepath = filepath if filepath else models_file
     all_models = _load_models_yaml(filepath)
 
     model_names = []

--- a/ml_peg/models/models.py
+++ b/ml_peg/models/models.py
@@ -14,8 +14,6 @@ if TYPE_CHECKING:
     from ase.calculators.calculator import Calculator
     from ase.calculators.mixing import SumCalculator
 
-current_models = None
-
 
 @dataclasses.dataclass(kw_only=True)
 class SumCalc:

--- a/ml_peg/models/models.yml
+++ b/ml_peg/models/models.yml
@@ -75,33 +75,33 @@ orb-v3-consv-omol:
   kwargs:
     name: "orb_v3_conservative_omol"
 
-mattersim-5M:
-  module: mattersim.forcefield
-  class_name: MatterSimCalculator
-  device: "cpu"
-  load_path: "mattersim-v1.0.0-5m"
-  trained_on_dispersion: false
-  level_of_theory: PBE
+# mattersim-5M:
+#   module: mattersim.forcefield
+#   class_name: MatterSimCalculator
+#   device: "cpu"
+#   load_path: "mattersim-v1.0.0-5m"
+#   trained_on_dispersion: false
+#   level_of_theory: PBE
 
 # uma-s-1p1-omat:
 #   module: fairchem.core
 #   class_name: FAIRChemCalculator
 #   device: "cpu"
-#   level_of_theory: PBE
-#   trained_on_dispersion: false
-#   kwargs:
-#     model_name: "uma-s-1p1"
+#   level_of_theory: PBE
+#   trained_on_dispersion: false
+#   kwargs:
+#     model_name: "uma-s-1p1"
 #     task_name: "omat"
 
-# uma-m-1p1-omat:
-#   module: fairchem.core
-#   class_name: FAIRChemCalculator
-#   device: "cpu"
-#   level_of_theory: PBE
-#   trained_on_dispersion: false
-#   kwargs:
-#     model_name: "uma-m-1p1"
-#     task_name: "omat"
+# uma-m-1p1-omat:
+#   module: fairchem.core
+#   class_name: FAIRChemCalculator
+#   device: "cpu"
+#   level_of_theory: PBE
+#   trained_on_dispersion: false
+#   kwargs:
+#     model_name: "uma-m-1p1"
+#     task_name: "omat"
 
 # GRACE-2L-OAM:
 #   module: tensorpotential.calculator
@@ -138,15 +138,15 @@ mattersim-5M:
 #     model: "mh-1"
 #     head: omol
 
-# uma-s-1p1-omol:
-#   module: fairchem.core
-#   class_name: FAIRChemCalculator
-#   device: "cpu"
-#   trained_on_dispersion: true
-#   level_of_theory: ωB97M-V/def2-TZVPD
-#   kwargs:
-#     model_name: "uma-s-1p1"
-#     task_name: "omol"
+# uma-s-1p1-omol:
+#   module: fairchem.core
+#   class_name: FAIRChemCalculator
+#   device: "cpu"
+#   trained_on_dispersion: true
+#   level_of_theory: ωB97M-V/def2-TZVPD
+#   kwargs:
+#     model_name: "uma-s-1p1"
+#     task_name: "omol"
 
 # uma-s-1p2-omol:
 #   module: fairchem.core
@@ -159,14 +159,14 @@ mattersim-5M:
 #     task_name: "omol"
 
 # uma-m-1p1-omol:
-#   module: fairchem.core
-#   class_name: FAIRChemCalculator
-#   device: "cpu"
-#   trained_on_dispersion: true
-#   level_of_theory: ωB97M-V/def2-TZVPD
-#   kwargs:
-#     model_name: "uma-m-1p1"
-#     task_name: "omol"
+#   module: fairchem.core
+#   class_name: FAIRChemCalculator
+#   device: "cpu"
+#   trained_on_dispersion: true
+#   level_of_theory: ωB97M-V/def2-TZVPD
+#   kwargs:
+#     model_name: "uma-m-1p1"
+#     task_name: "omol"
 
 pet-mad:
   module: pet_mad.calculator

--- a/ml_peg/models/models.yml
+++ b/ml_peg/models/models.yml
@@ -75,33 +75,33 @@ orb-v3-consv-omol:
   kwargs:
     name: "orb_v3_conservative_omol"
 
-# mattersim-5M:
-#   module: mattersim.forcefield
-#   class_name: MatterSimCalculator
-#   device: "cpu"
-#   load_path: "mattersim-v1.0.0-5m"
-#   trained_on_dispersion: false
-#   level_of_theory: PBE
+mattersim-5M:
+  module: mattersim.forcefield
+  class_name: MatterSimCalculator
+  device: "cpu"
+  load_path: "mattersim-v1.0.0-5m"
+  trained_on_dispersion: false
+  level_of_theory: PBE
 
 # uma-s-1p1-omat:
 #   module: fairchem.core
 #   class_name: FAIRChemCalculator
 #   device: "cpu"
-#   level_of_theory: PBE
-#   trained_on_dispersion: false
-#   kwargs:
-#     model_name: "uma-s-1p1"
+#   level_of_theory: PBE
+#   trained_on_dispersion: false
+#   kwargs:
+#     model_name: "uma-s-1p1"
 #     task_name: "omat"
 
-# uma-m-1p1-omat:
-#   module: fairchem.core
-#   class_name: FAIRChemCalculator
-#   device: "cpu"
-#   level_of_theory: PBE
-#   trained_on_dispersion: false
-#   kwargs:
-#     model_name: "uma-m-1p1"
-#     task_name: "omat"
+# uma-m-1p1-omat:
+#   module: fairchem.core
+#   class_name: FAIRChemCalculator
+#   device: "cpu"
+#   level_of_theory: PBE
+#   trained_on_dispersion: false
+#   kwargs:
+#     model_name: "uma-m-1p1"
+#     task_name: "omat"
 
 # GRACE-2L-OAM:
 #   module: tensorpotential.calculator
@@ -138,15 +138,15 @@ orb-v3-consv-omol:
 #     model: "mh-1"
 #     head: omol
 
-# uma-s-1p1-omol:
-#   module: fairchem.core
-#   class_name: FAIRChemCalculator
-#   device: "cpu"
-#   trained_on_dispersion: true
-#   level_of_theory: ωB97M-V/def2-TZVPD
-#   kwargs:
-#     model_name: "uma-s-1p1"
-#     task_name: "omol"
+# uma-s-1p1-omol:
+#   module: fairchem.core
+#   class_name: FAIRChemCalculator
+#   device: "cpu"
+#   trained_on_dispersion: true
+#   level_of_theory: ωB97M-V/def2-TZVPD
+#   kwargs:
+#     model_name: "uma-s-1p1"
+#     task_name: "omol"
 
 # uma-s-1p2-omol:
 #   module: fairchem.core
@@ -159,14 +159,14 @@ orb-v3-consv-omol:
 #     task_name: "omol"
 
 # uma-m-1p1-omol:
-#   module: fairchem.core
-#   class_name: FAIRChemCalculator
-#   device: "cpu"
-#   trained_on_dispersion: true
-#   level_of_theory: ωB97M-V/def2-TZVPD
-#   kwargs:
-#     model_name: "uma-m-1p1"
-#     task_name: "omol"
+#   module: fairchem.core
+#   class_name: FAIRChemCalculator
+#   device: "cpu"
+#   trained_on_dispersion: true
+#   level_of_theory: ωB97M-V/def2-TZVPD
+#   kwargs:
+#     model_name: "uma-m-1p1"
+#     task_name: "omol"
 
 pet-mad:
   module: pet_mad.calculator

--- a/tests/test_high_pressure_relaxation_regression.py
+++ b/tests/test_high_pressure_relaxation_regression.py
@@ -15,8 +15,8 @@ from ml_peg.calcs.bulk_crystal.high_pressure_relaxation.calc_high_pressure_relax
     load_structures,
     relax_with_pressure,
 )
+from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
-from ml_peg.models.models import current_models
 
 N_TEST_STRUCTURES = 3
 VOLUME_ATOL = 0.001


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Allow models YAML file to be specified for all CLI commands (`ml_peg calc/analyse/app/list`).

I'd originally thought this may be an option parsed instead of the list of models, but I think a separate input makes sense, since then it's also filterable.

This also moves the 'global' inputs to the models init file, which means they can be accessed without the relatively heavy imports in models.py, which otherwise slow down the CLI noticeably.

## Linked issue

Resolves #496

## Testing

Tested locally for most commands, but could use fairly careful additional testing since it touches a lot. 
