### PR TITLE
⚡ Bolt: Cache framework registry loading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-19 - Caching YAML Load for Model Parsing
 **Learning:** `yaml.safe_load` on large configuration files like `models.yml` is significantly slower than parsing JSON or doing other basic IO. It can become a bottleneck when called repeatedly throughout an application's lifecycle (e.g., getting subsets of models, instantiating apps).
 **Action:** Always memoize or `@lru_cache` functions that load static, read-only configuration files (like `models.yml`) to prevent repeated disk I/O and parsing overhead.
+## 2024-05-19 - Caching YAML Load for Framework Parsing
+**Learning:** Similar to `models.yml`, the application frequently loads `frameworks.yml` via `load_framework_registry` on page loads and during app building. Parsing YAML files is a known bottleneck.
+**Action:** When working with static, read-only configuration YAML files, ensure they are wrapped with an `@lru_cache` and that any public interface returns a `copy.deepcopy()` to prevent unintended mutations from rippling back into the cached object.

--- a/ml_peg/app/utils/utils.py
+++ b/ml_peg/app/utils/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, Sequence
+import copy
 from functools import lru_cache
 import json
 from pathlib import Path
@@ -927,9 +928,10 @@ def normalize_framework_id(framework_id: str) -> str:
     return cleaned
 
 
-def load_framework_registry() -> dict[str, FrameworkEntry]:
+@lru_cache(maxsize=1)
+def _load_framework_registry() -> dict[str, FrameworkEntry]:
     """
-    Load framework badge metadata from ``frameworks.yml``.
+    Load and cache framework badge metadata from ``frameworks.yml``.
 
     Returns
     -------
@@ -981,6 +983,18 @@ def load_framework_registry() -> dict[str, FrameworkEntry]:
         registry[normalized_id] = registry_entry
 
     return registry
+
+
+def load_framework_registry() -> dict[str, FrameworkEntry]:
+    """
+    Load framework badge metadata from ``frameworks.yml``.
+
+    Returns
+    -------
+    dict[str, FrameworkEntry]
+        Mapping of framework IDs to display configuration.
+    """
+    return copy.deepcopy(_load_framework_registry())
 
 
 def get_framework_config(framework_id: str) -> FrameworkEntry:


### PR DESCRIPTION
💡 **What:**
Memoized the reading and parsing of the `frameworks.yml` file in `ml_peg/app/utils/utils.py`. The private method `_load_framework_registry` now utilizes `functools.lru_cache(maxsize=1)`. The public `load_framework_registry` method returns `copy.deepcopy()` of the cache to guarantee the global state cannot be mistakenly mutated.

🎯 **Why:**
The application calls `get_framework_config` (which in turn calls `load_framework_registry`) heavily during initial layout building and navigation. Parsing YAML is computationally expensive and disk I/O introduces latency. Repeatedly re-parsing a static `frameworks.yml` configuration represents a clear bottleneck.

📊 **Impact:**
Substantially decreases page load latency and application startup time by avoiding repetitive disk reads and Python YAML decoding for the framework configuration mapping.

🔬 **Measurement:**
We can benchmark the startup routine `build_full_app` and navigate between pages/frameworks in the UI. A timing trace or line profiler on `get_framework_config()` will show a dramatic reduction in wall time after the initial cache population.

---
*PR created automatically by Jules for task [6177802362191715950](https://jules.google.com/task/6177802362191715950) started by @alinelena*