### PR TITLE
Fix precision being passed to UMA

### DIFF
--- a/ml_peg/models/models.py
+++ b/ml_peg/models/models.py
@@ -221,9 +221,14 @@ class FairChemCalc(SumCalc):
     default_dtype: str = "float32"
     overrides: dict = dataclasses.field(default_factory=dict)
 
-    def get_calculator(self) -> Calculator:
+    def get_calculator(self, **kwargs) -> Calculator:
         """
         Prepare and load the calculator.
+
+        Parameters
+        ----------
+        **kwargs
+            Unused additional keyword arguments.
 
         Returns
         -------


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

UMA's `get_calculator` does not accept precision, so causes errors to be raised. This adds arbitrary kwargs that can be ignored safely. We alternatively just accept `precision` specifically.

## Testing

Tested locally
