### PR TITLE
⚡ Bolt: [performance improvement] Cache YAML configuration loads in app utils

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-19 - Caching YAML Load for Model Parsing
 **Learning:** `yaml.safe_load` on large configuration files like `models.yml` is significantly slower than parsing JSON or doing other basic IO. It can become a bottleneck when called repeatedly throughout an application's lifecycle (e.g., getting subsets of models, instantiating apps).
 **Action:** Always memoize or `@lru_cache` functions that load static, read-only configuration files (like `models.yml`) to prevent repeated disk I/O and parsing overhead.
+## 2024-05-19 - Caching YAML Configuration for UI Components
+**Learning:** `yaml.safe_load` overhead is not just an issue for large model registries but also applies to repeated loading of UI configurations like `frameworks.yml` (for badges) and `faqs.yml` (for dropdowns). Frequent calls during UI generation cause unnecessary slowdowns and disk I/O. Using `copy.deepcopy()` is crucial when returning memoized data structures to prevent unintended mutation by downstream callers, which would pollute the global cache.
+**Action:** Extend the pattern of memoizing static YAML configurations to UI-specific data. Ensure the returned data is deeply copied (`copy.deepcopy`) to guarantee immutability of the `@lru_cache` source.

--- a/ml_peg/app/utils/build_components.py
+++ b/ml_peg/app/utils/build_components.py
@@ -327,7 +327,14 @@ def build_weight_components(
 
 @lru_cache(maxsize=1)
 def _load_faqs_yaml() -> list[dict] | None:
-    """Load and cache the FAQs YAML file to avoid repeated disk reads."""
+    """
+    Load and cache the FAQs YAML file to avoid repeated disk reads.
+
+    Returns
+    -------
+    list[dict] | None
+        The loaded FAQs list, or None if the file is not found.
+    """
     faqs_path = Path(__file__).parent / "faqs.yml"
     try:
         with open(faqs_path, encoding="utf8") as f:

--- a/ml_peg/app/utils/build_components.py
+++ b/ml_peg/app/utils/build_components.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import copy
+from functools import lru_cache
 from importlib import metadata
 from pathlib import Path
 import time
@@ -323,6 +325,17 @@ def build_weight_components(
     return Div(layout)
 
 
+@lru_cache(maxsize=1)
+def _load_faqs_yaml() -> list[dict] | None:
+    """Load and cache the FAQs YAML file to avoid repeated disk reads."""
+    faqs_path = Path(__file__).parent / "faqs.yml"
+    try:
+        with open(faqs_path, encoding="utf8") as f:
+            return yaml.safe_load(f)
+    except FileNotFoundError:
+        return None
+
+
 def build_faqs() -> Div:
     """
     Build FAQ section with collapsible dropdowns from YAML file.
@@ -333,12 +346,9 @@ def build_faqs() -> Div:
         Styled FAQ section with questions as dropdown titles and answers inside.
     """
     # Load FAQs from YAML file
-    faqs_path = Path(__file__).parent / "faqs.yml"
+    faqs_data = _load_faqs_yaml()
 
-    try:
-        with open(faqs_path, encoding="utf8") as f:
-            faqs_data = yaml.safe_load(f)
-    except FileNotFoundError:
+    if faqs_data is None:
         return Div(
             "FAQs file not found",
             style={
@@ -350,6 +360,9 @@ def build_faqs() -> Div:
 
     if not faqs_data or not isinstance(faqs_data, list):
         return Div("No FAQs available")
+
+    # To ensure safety of the cached list (though it's only read), deepcopy it
+    faqs_data = copy.deepcopy(faqs_data)
 
     # Build FAQ dropdowns
     faq_components = []

--- a/ml_peg/app/utils/utils.py
+++ b/ml_peg/app/utils/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, MutableMapping, Sequence
+import copy
 from functools import lru_cache
 import json
 from pathlib import Path
@@ -927,6 +928,7 @@ def normalize_framework_id(framework_id: str) -> str:
     return cleaned
 
 
+@lru_cache(maxsize=1)
 def load_framework_registry() -> dict[str, FrameworkEntry]:
     """
     Load framework badge metadata from ``frameworks.yml``.
@@ -1005,7 +1007,7 @@ def get_framework_config(framework_id: str) -> FrameworkEntry:
     normalized_id = normalize_framework_id(framework_id)
     registry = load_framework_registry()
     try:
-        return registry[normalized_id]
+        return copy.deepcopy(registry[normalized_id])
     except KeyError as exc:
         known_ids = ", ".join(sorted(registry))
         raise ValueError(


### PR DESCRIPTION
**💡 What:** 
Added `@lru_cache(maxsize=1)` to `load_framework_registry` in `ml_peg/app/utils/utils.py` and `_load_faqs_yaml` in `ml_peg/app/utils/build_components.py`. Used `copy.deepcopy()` before returning the cached values to prevent any unintended mutation from downstream calls.

**🎯 Why:** 
The application frequently needs to read `frameworks.yml` (for rendering badges) and `faqs.yml` (for dropdowns) during component rendering. The `yaml.safe_load` operation combined with disk I/O is a known performance bottleneck in Python. Loading these static files once and caching them drastically speeds up UI generation and avoids repetitive overhead.

**📊 Impact:** 
Prevents file reading and YAML parsing overhead entirely on subsequent calls, replacing it with a quick dictionary deepcopy. This should tangibly reduce Dash app instantiation and render times.

**🔬 Measurement:** 
Run the test suite or manually profile calls to `build_faqs()` and `get_framework_config()` before and after this change. The cache hit rate should be nearly 100% on subsequent renders, yielding O(1) time complexity (plus deepcopy time).

---
*PR created automatically by Jules for task [9542593272263519501](https://jules.google.com/task/9542593272263519501) started by @alinelena*