### PR TITLE
add elastic tensor voigt form check and conversion if needed

### DIFF
--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -160,16 +160,35 @@ class CustomElasticityBenchmark(Benchmark):
             ),
             f"crystal_system_{model_name}": key,
         }
-        
-        
+
+
 def elastic_tensor_to_voigt(x):
     """
     Convert elastic tensor-like objects to 6x6 Voigt form.
-    For some models, matcalc returns the tensor as a plain 
-    numpy.ndarray with shape (3, 3, 3, 3), not as a pymatgen 
-    tensor object. NumPy arrays do not have .voigt, so the 
-    final dataframe conversion fails -> we need to be robust to this
 
+    For some models, matcalc returns the tensor as a plain
+    numpy.ndarray with shape (3, 3, 3, 3), not as a pymatgen
+    tensor object. NumPy arrays do not have .voigt, so the
+    final dataframe conversion fails, so this conversion must handle both forms.
+
+    Parameters
+    ----------
+    x : object
+        Elastic tensor-like object to convert. This may be None, NaN, an object
+        with a voigt attribute, a dictionary containing a raw tensor, a 6x6
+        array, or a 3x3x3x3 array.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        Tensor in 6x6 Voigt form, or None if ``x`` is None or NaN.
+
+    Raises
+    ------
+    TypeError
+        If ``x`` is a dictionary without a raw tensor entry.
+    ValueError
+        If the tensor shape is unsupported.
     """
     if x is None:
         return None
@@ -206,13 +225,12 @@ def elastic_tensor_to_voigt(x):
         ]
 
         out = np.empty((6, 6), dtype=arr.dtype)
-        for I, (i, j) in enumerate(voigt_pairs):
-            for J, (k, l) in enumerate(voigt_pairs):
-                out[I, J] = arr[i, j, k, l]
+        for row_idx, (i, j) in enumerate(voigt_pairs):
+            for col_idx, (k, m) in enumerate(voigt_pairs):
+                out[row_idx, col_idx] = arr[i, j, k, m]
         return out
 
     raise ValueError(f"Unsupported elastic tensor shape: {arr.shape}")
-
 
 
 def run_elasticity_benchmark(

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -160,6 +160,59 @@ class CustomElasticityBenchmark(Benchmark):
             ),
             f"crystal_system_{model_name}": key,
         }
+        
+        
+def elastic_tensor_to_voigt(x):
+    """
+    Convert elastic tensor-like objects to 6x6 Voigt form.
+    For some models, matcalc returns the tensor as a plain 
+    numpy.ndarray with shape (3, 3, 3, 3), not as a pymatgen 
+    tensor object. NumPy arrays do not have .voigt, so the 
+    final dataframe conversion fails -> we need to be robust to this
+
+    """
+    if x is None:
+        return None
+
+    if isinstance(x, float) and np.isnan(x):
+        return None
+
+    # pymatgen Tensor / ElasticTensor case
+    if hasattr(x, "voigt"):
+        return np.asarray(x.voigt)
+
+    # benchmark dict case, e.g. DFT field
+    if isinstance(x, dict):
+        if "raw" in x:
+            x = x["raw"]
+        else:
+            raise TypeError(f"Cannot convert tensor dict with keys {x.keys()}")
+
+    arr = np.asarray(x)
+
+    # Already Voigt
+    if arr.shape == (6, 6):
+        return arr
+
+    # Full rank-4 tensor C_ijkl
+    if arr.shape == (3, 3, 3, 3):
+        voigt_pairs = [
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (1, 2),
+            (0, 2),
+            (0, 1),
+        ]
+
+        out = np.empty((6, 6), dtype=arr.dtype)
+        for I, (i, j) in enumerate(voigt_pairs):
+            for J, (k, l) in enumerate(voigt_pairs):
+                out[I, J] = arr[i, j, k, l]
+        return out
+
+    raise ValueError(f"Unsupported elastic tensor shape: {arr.shape}")
+
 
 
 def run_elasticity_benchmark(
@@ -253,15 +306,19 @@ def run_elasticity_benchmark(
     # Drop structure column before CSV processing
     results = results.drop(columns=["final_structure"], errors="ignore")
 
-    results["elastic_tensor_DFT"] = results["elastic_tensor_DFT"].apply(
-        lambda x: np.array(x["raw"]) if x is not None else None
-    )
+    # results["elastic_tensor_DFT"] = results["elastic_tensor_DFT"].apply(
+    #     lambda x: np.array(x["raw"]) if x is not None else None
+    # )
+
+    # for col in results.columns:
+    #     if col.startswith("elastic_tensor_") and col != "elastic_tensor_DFT":
+    #         results[col] = results[col].apply(
+    #             lambda x: x.voigt if x is not None else None
+    #         )
 
     for col in results.columns:
-        if col.startswith("elastic_tensor_") and col != "elastic_tensor_DFT":
-            results[col] = results[col].apply(
-                lambda x: x.voigt if x is not None else None
-            )
+        if col.startswith("elastic_tensor_"):
+            results[col] = results[col].apply(elastic_tensor_to_voigt)
 
     results.to_csv(out_dir / "moduli_results.csv", index=False)
 

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -306,16 +306,6 @@ def run_elasticity_benchmark(
     # Drop structure column before CSV processing
     results = results.drop(columns=["final_structure"], errors="ignore")
 
-    # results["elastic_tensor_DFT"] = results["elastic_tensor_DFT"].apply(
-    #     lambda x: np.array(x["raw"]) if x is not None else None
-    # )
-
-    # for col in results.columns:
-    #     if col.startswith("elastic_tensor_") and col != "elastic_tensor_DFT":
-    #         results[col] = results[col].apply(
-    #             lambda x: x.voigt if x is not None else None
-    #         )
-
     for col in results.columns:
         if col.startswith("elastic_tensor_"):
             results[col] = results[col].apply(elastic_tensor_to_voigt)

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -236,7 +236,7 @@ def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | None:
     if hasattr(tensor, "voigt"):
         return np.asarray(tensor.voigt)
 
-    # Matcalc/checkpoint serialisation stores tensor payloads as dictionaries.
+    # Reference data and JSON checkpoints can store tensor payloads as dictionaries.
     if isinstance(tensor, dict):
         if "raw" in tensor:
             tensor = tensor["raw"]

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -25,38 +25,6 @@ MODELS = load_models(current_models)
 OUT_PATH = Path(__file__).parent / "outputs"
 
 
-def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | float:
-    """
-    Convert an elastic tensor object or array to a 6x6 Voigt matrix.
-
-    Parameters
-    ----------
-    tensor
-        Elastic tensor returned by matcalc.
-
-    Returns
-    -------
-    np.ndarray | float
-        Voigt matrix, or NaN when tensor data is unavailable.
-    """
-    if hasattr(tensor, "voigt"):
-        return np.asarray(tensor.voigt)
-
-    if isinstance(tensor, dict):
-        tensor = tensor.get("data")
-
-    try:
-        tensor_array = np.asarray(tensor, dtype=float)
-    except (TypeError, ValueError):
-        return np.nan
-
-    if tensor_array.shape == (6, 6):
-        return tensor_array
-    if tensor_array.shape == (3, 3, 3, 3):
-        return np.asarray(ElasticTensor(tensor_array).voigt)
-    return np.nan
-
-
 def get_crystal_system(struct: Structure) -> str:
     """
     Determine a crystal-system label.
@@ -198,7 +166,7 @@ class CustomElasticityBenchmark(Benchmark):
         }
 
 
-def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | None:
+def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | float:
     """
     Convert elastic tensor-like objects to 6x6 Voigt form.
 
@@ -216,21 +184,12 @@ def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | None:
 
     Returns
     -------
-    numpy.ndarray or None
-        Tensor in 6x6 Voigt form, or None if ``tensor`` is None or NaN.
-
-    Raises
-    ------
-    TypeError
-        If ``tensor`` is a dictionary without tensor data.
-    ValueError
-        If the tensor shape is unsupported.
+    numpy.ndarray or float
+        Tensor in 6x6 Voigt form, or NaN if ``tensor`` is missing or
+        cannot be converted.
     """
-    if tensor is None:
-        return None
-
-    if isinstance(tensor, float) and np.isnan(tensor):
-        return None
+    if tensor is None or (isinstance(tensor, float) and np.isnan(tensor)):
+        return np.nan
 
     # pymatgen Tensor / ElasticTensor case
     if hasattr(tensor, "voigt"):
@@ -243,32 +202,18 @@ def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | None:
         elif "data" in tensor:
             tensor = tensor["data"]
         else:
-            raise TypeError(f"Cannot convert tensor dict with keys {tensor.keys()}")
+            return np.nan
 
-    arr = np.asarray(tensor)
+    try:
+        arr = np.asarray(tensor, dtype=float)
+    except (TypeError, ValueError):
+        return np.nan
 
-    # Already Voigt
     if arr.shape == (6, 6):
         return arr
-
-    # Full rank-4 tensor C_ijkl
     if arr.shape == (3, 3, 3, 3):
-        voigt_pairs = [
-            (0, 0),
-            (1, 1),
-            (2, 2),
-            (1, 2),
-            (0, 2),
-            (0, 1),
-        ]
-
-        out = np.empty((6, 6), dtype=arr.dtype)
-        for row_idx, (i, j) in enumerate(voigt_pairs):
-            for col_idx, (k, m) in enumerate(voigt_pairs):
-                out[row_idx, col_idx] = arr[i, j, k, m]
-        return out
-
-    raise ValueError(f"Unsupported elastic tensor shape: {arr.shape}")
+        return np.asarray(ElasticTensor(arr).voigt)
+    return np.nan
 
 
 def run_elasticity_benchmark(

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -236,7 +236,7 @@ def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | None:
     if hasattr(tensor, "voigt"):
         return np.asarray(tensor.voigt)
 
-    # Reference data and JSON checkpoints can store tensor payloads as dictionaries.
+    # Reference data and JSON checkpoints can store tensors as dictionaries.
     if isinstance(tensor, dict):
         if "raw" in tensor:
             tensor = tensor["raw"]

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -196,6 +196,59 @@ class CustomElasticityBenchmark(Benchmark):
                 else np.nan
             ),
         }
+        
+        
+def elastic_tensor_to_voigt(x):
+    """
+    Convert elastic tensor-like objects to 6x6 Voigt form.
+    For some models, matcalc returns the tensor as a plain 
+    numpy.ndarray with shape (3, 3, 3, 3), not as a pymatgen 
+    tensor object. NumPy arrays do not have .voigt, so the 
+    final dataframe conversion fails -> we need to be robust to this
+
+    """
+    if x is None:
+        return None
+
+    if isinstance(x, float) and np.isnan(x):
+        return None
+
+    # pymatgen Tensor / ElasticTensor case
+    if hasattr(x, "voigt"):
+        return np.asarray(x.voigt)
+
+    # benchmark dict case, e.g. DFT field
+    if isinstance(x, dict):
+        if "raw" in x:
+            x = x["raw"]
+        else:
+            raise TypeError(f"Cannot convert tensor dict with keys {x.keys()}")
+
+    arr = np.asarray(x)
+
+    # Already Voigt
+    if arr.shape == (6, 6):
+        return arr
+
+    # Full rank-4 tensor C_ijkl
+    if arr.shape == (3, 3, 3, 3):
+        voigt_pairs = [
+            (0, 0),
+            (1, 1),
+            (2, 2),
+            (1, 2),
+            (0, 2),
+            (0, 1),
+        ]
+
+        out = np.empty((6, 6), dtype=arr.dtype)
+        for I, (i, j) in enumerate(voigt_pairs):
+            for J, (k, l) in enumerate(voigt_pairs):
+                out[I, J] = arr[i, j, k, l]
+        return out
+
+    raise ValueError(f"Unsupported elastic tensor shape: {arr.shape}")
+
 
 
 def run_elasticity_benchmark(
@@ -290,12 +343,8 @@ def run_elasticity_benchmark(
     # Drop structure column before CSV processing
     results = results.drop(columns=["final_structure"], errors="ignore")
 
-    results["elastic_tensor_DFT"] = results["elastic_tensor_DFT"].apply(
-        lambda x: np.array(x["raw"]) if x is not None else None
-    )
-
     for col in results.columns:
-        if col.startswith("elastic_tensor_") and col != "elastic_tensor_DFT":
+        if col.startswith("elastic_tensor_"):
             results[col] = results[col].apply(elastic_tensor_to_voigt)
 
     results.to_csv(out_dir / "moduli_results.csv", index=False)

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -236,7 +236,7 @@ def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | None:
     if hasattr(tensor, "voigt"):
         return np.asarray(tensor.voigt)
 
-    # benchmark dict case, e.g. DFT field
+    # Matcalc/checkpoint serialisation stores tensor payloads as dictionaries.
     if isinstance(tensor, dict):
         if "raw" in tensor:
             tensor = tensor["raw"]

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -196,16 +196,35 @@ class CustomElasticityBenchmark(Benchmark):
                 else np.nan
             ),
         }
-        
-        
+
+
 def elastic_tensor_to_voigt(x):
     """
     Convert elastic tensor-like objects to 6x6 Voigt form.
-    For some models, matcalc returns the tensor as a plain 
-    numpy.ndarray with shape (3, 3, 3, 3), not as a pymatgen 
-    tensor object. NumPy arrays do not have .voigt, so the 
-    final dataframe conversion fails -> we need to be robust to this
 
+    For some models, matcalc returns the tensor as a plain
+    numpy.ndarray with shape (3, 3, 3, 3), not as a pymatgen
+    tensor object. NumPy arrays do not have .voigt, so the
+    final dataframe conversion fails, so this conversion must handle both forms.
+
+    Parameters
+    ----------
+    x : object
+        Elastic tensor-like object to convert. This may be None, NaN, an object
+        with a voigt attribute, a dictionary containing a raw tensor, a 6x6
+        array, or a 3x3x3x3 array.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        Tensor in 6x6 Voigt form, or None if ``x`` is None or NaN.
+
+    Raises
+    ------
+    TypeError
+        If ``x`` is a dictionary without a raw tensor entry.
+    ValueError
+        If the tensor shape is unsupported.
     """
     if x is None:
         return None
@@ -242,13 +261,12 @@ def elastic_tensor_to_voigt(x):
         ]
 
         out = np.empty((6, 6), dtype=arr.dtype)
-        for I, (i, j) in enumerate(voigt_pairs):
-            for J, (k, l) in enumerate(voigt_pairs):
-                out[I, J] = arr[i, j, k, l]
+        for row_idx, (i, j) in enumerate(voigt_pairs):
+            for col_idx, (k, m) in enumerate(voigt_pairs):
+                out[row_idx, col_idx] = arr[i, j, k, m]
         return out
 
     raise ValueError(f"Unsupported elastic tensor shape: {arr.shape}")
-
 
 
 def run_elasticity_benchmark(

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -198,7 +198,7 @@ class CustomElasticityBenchmark(Benchmark):
         }
 
 
-def elastic_tensor_to_voigt(x):
+def elastic_tensor_to_voigt(tensor: Any) -> np.ndarray | None:
     """
     Convert elastic tensor-like objects to 6x6 Voigt form.
 
@@ -209,41 +209,43 @@ def elastic_tensor_to_voigt(x):
 
     Parameters
     ----------
-    x : object
+    tensor
         Elastic tensor-like object to convert. This may be None, NaN, an object
-        with a voigt attribute, a dictionary containing a raw tensor, a 6x6
-        array, or a 3x3x3x3 array.
+        with a voigt attribute, a dictionary containing tensor data, a 6x6 array,
+        or a 3x3x3x3 array.
 
     Returns
     -------
     numpy.ndarray or None
-        Tensor in 6x6 Voigt form, or None if ``x`` is None or NaN.
+        Tensor in 6x6 Voigt form, or None if ``tensor`` is None or NaN.
 
     Raises
     ------
     TypeError
-        If ``x`` is a dictionary without a raw tensor entry.
+        If ``tensor`` is a dictionary without tensor data.
     ValueError
         If the tensor shape is unsupported.
     """
-    if x is None:
+    if tensor is None:
         return None
 
-    if isinstance(x, float) and np.isnan(x):
+    if isinstance(tensor, float) and np.isnan(tensor):
         return None
 
     # pymatgen Tensor / ElasticTensor case
-    if hasattr(x, "voigt"):
-        return np.asarray(x.voigt)
+    if hasattr(tensor, "voigt"):
+        return np.asarray(tensor.voigt)
 
     # benchmark dict case, e.g. DFT field
-    if isinstance(x, dict):
-        if "raw" in x:
-            x = x["raw"]
+    if isinstance(tensor, dict):
+        if "raw" in tensor:
+            tensor = tensor["raw"]
+        elif "data" in tensor:
+            tensor = tensor["data"]
         else:
-            raise TypeError(f"Cannot convert tensor dict with keys {x.keys()}")
+            raise TypeError(f"Cannot convert tensor dict with keys {tensor.keys()}")
 
-    arr = np.asarray(x)
+    arr = np.asarray(tensor)
 
     # Already Voigt
     if arr.shape == (6, 6):


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

<!-- Describe your proposed changes. This can be brief, as most information can be in the linked issue. -->

    For some models, matcalc returns the tensor as a plain 
    numpy.ndarray with shape (3, 3, 3, 3), not as a pymatgen 
    tensor object. NumPy arrays do not have .voigt, so the 
    final dataframe conversion fails -> we need to be robust to this


@Fraser-Birks i can't add you as a reviewer but would be good to scan over, thanks!

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #

## Testing
ran elas benchmark
<!-- How have your proposed changes been tested? -->
