### PR TITLE
⚡ Bolt: Replace `iterrows` with `itertuples` for faster DataFrame iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+## 2024-05-19 - Pandas `iterrows` Bottleneck
+**Learning:** Iterating over Pandas DataFrames with `iterrows()` is a common performance bottleneck in the codebase. When replacing `iterrows` with `itertuples`, direct attribute access (e.g. `row.Reaction`) or `row._asdict()` should be used instead of `getattr(row, "Reaction")` to avoid Ruff B009 errors, and `row._asdict()` is needed when the column name is derived from a variable (e.g. `benchmark.index_name`) which could be an invalid python identifier.
+**Action:** Use `itertuples(index=False)` instead of `iterrows()`, and use direct attribute access or `._asdict()` as appropriate.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -234,13 +234,15 @@ def run_elasticity_benchmark(
     )
 
     # Save relaxed structures to extxyz for visualisation
+    # Bolt: Replace iterrows with itertuples for better performance
     atoms_list = []
-    for _, row in results.iterrows():
-        struct = row.get("final_structure")
+    for row in results.itertuples(index=False):
+        row_dict = row._asdict()
+        struct = getattr(row, "final_structure", None)
         if struct is not None:
             atoms = AseAtomsAdaptor.get_atoms(struct).copy()
             atoms.calc = None
-            atoms.info = {"mp_id": row[benchmark.index_name]}
+            atoms.info = {"mp_id": row_dict[benchmark.index_name]}
             atoms_list.append(atoms)
     if atoms_list:
         ase_write(

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -85,9 +85,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # Bolt: Replace iterrows with itertuples for better performance
+    for row in df.itertuples(index=False):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -83,9 +83,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # Bolt: Replace iterrows with itertuples for better performance
+    for row in df.itertuples(index=False):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -105,11 +105,14 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # Bolt: Replace iterrows with itertuples for better performance
+        for row in tqdm(
+            df_refs.itertuples(index=False), dataset, total=df_refs.shape[0]
+        ):
             atoms_list = []
-            identifier = row["Reaction"]
-            reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.
-            e_rel_ref = row["Reference"]
+            identifier = row.Reaction
+            reactions = row.Stoichiometry.split(",")  # Parse stoichiometry string.
+            e_rel_ref = row.Reference
             num_species = len(reactions) // 2  # Each species has coefficient and name.
 
             e_rel_model = 0


### PR DESCRIPTION
💡 **What**: Replaced pandas `iterrows()` with `itertuples()` in multiple calculation scripts (`calc_elasticity.py`, `gscdb138.py`, `calc_solvMPCONF196.py`, `calc_MPCONF196.py`).
🎯 **Why**: Iterating over Pandas DataFrames with `iterrows()` is a known performance bottleneck as it yields Series objects. `itertuples()` returns namedtuples, which is significantly faster.
📊 **Impact**: Faster iteration over calculation results and reference dataframes, reducing overhead when parsing benchmark outputs and calculating relative energies.
🔬 **Measurement**: Run the test suite and benchmark calculations to verify identical results with improved execution time.

---
*PR created automatically by Jules for task [18089360447646413726](https://jules.google.com/task/18089360447646413726) started by @alinelena*