### PR TITLE
mark molecular dynamics tests as very slow

### DIFF
--- a/ml_peg/calcs/molecular_dynamics/liquid_densities/calc_liquid_densities.py
+++ b/ml_peg/calcs/molecular_dynamics/liquid_densities/calc_liquid_densities.py
@@ -124,6 +124,7 @@ def run_npt(atoms, calc, output_fname):
     dyn.run(steps=NUM_MD_STEPS - nsteps)
 
 
+@pytest.mark.very_slow
 @pytest.mark.parametrize("mlip", MODELS.items())
 def test_liquid_densities(mlip: tuple[str, Any], system_id) -> None:
     """

--- a/ml_peg/calcs/molecular_dynamics/water_density/calc_water_density.py
+++ b/ml_peg/calcs/molecular_dynamics/water_density/calc_water_density.py
@@ -120,6 +120,7 @@ def run_npt(atoms, calc, output_fname, temperature):
     dyn.run(steps=NUM_MD_STEPS - nsteps)
 
 
+@pytest.mark.very_slow
 @pytest.mark.parametrize("mlip", MODELS.items())
 def test_liquid_densities(mlip: tuple[str, Any], temperature_idx: int) -> None:
     """


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Currently, molecular dynamics tests aren't marked as `very_slow` so that they run even when  `--no-run-slow` is enabled.
This fixes it.

## Testing

I verified tests were skipped correctly now
