### PR TITLE
⚡ Bolt: Replace iterrows with itertuples for faster dataframe iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-19 - Pandas Iteration Bottleneck
+**Learning:** `DataFrame.iterrows()` is extremely slow because it creates a new Pandas Series object for every row. It significantly impacts performance when processing large benchmark result dataframes.
+**Action:** Always use `DataFrame.itertuples(index=False)` for read-only iteration. It yields lightweight namedtuples which is significantly faster. If dictionary access is required, especially with dynamic or non-standard column names, consider iterating over `df.to_dict('records')` to prevent `itertuples()` from mangling invalid Python identifiers into positional names (like `_1`).

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -235,12 +235,14 @@ def run_elasticity_benchmark(
 
     # Save relaxed structures to extxyz for visualisation
     atoms_list = []
-    for _, row in results.iterrows():
-        struct = row.get("final_structure")
+    # PERF: Use to_dict('records') instead of iterrows for faster iteration
+    # and to preserve complex column names that itertuples might alter.
+    for row_dict in results.to_dict("records"):
+        struct = row_dict.get("final_structure")
         if struct is not None:
             atoms = AseAtomsAdaptor.get_atoms(struct).copy()
             atoms.calc = None
-            atoms.info = {"mp_id": row[benchmark.index_name]}
+            atoms.info = {"mp_id": row_dict[benchmark.index_name]}
             atoms_list.append(atoms)
     if atoms_list:
         ase_write(

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -85,9 +85,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # PERF: Use itertuples instead of iterrows for significantly faster iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -83,9 +83,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # PERF: Use itertuples instead of iterrows for significantly faster iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -105,11 +105,14 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # PERF: Use itertuples instead of iterrows for significantly faster iteration
+        for row in tqdm(
+            df_refs.itertuples(index=False), dataset, total=df_refs.shape[0]
+        ):
             atoms_list = []
-            identifier = row["Reaction"]
-            reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.
-            e_rel_ref = row["Reference"]
+            identifier = row.Reaction
+            reactions = row.Stoichiometry.split(",")  # Parse stoichiometry string.
+            e_rel_ref = row.Reference
             num_species = len(reactions) // 2  # Each species has coefficient and name.
 
             e_rel_model = 0


### PR DESCRIPTION
💡 What: Replaced pandas `.iterrows()` with `.itertuples()` or `.to_dict('records')` across calculation and benchmark scripts.
🎯 Why: `.iterrows()` is a known performance bottleneck as it creates a pandas Series for every row. `.itertuples()` yields namedtuples which is significantly faster. `.to_dict('records')` handles complex/invalid Python identifiers safely compared to `itertuples()`.
📊 Impact: Reduces iteration overhead substantially during benchmark processing.
🔬 Measurement: Check execution time of benchmark scripts.

---
*PR created automatically by Jules for task [15602670289288983959](https://jules.google.com/task/15602670289288983959) started by @alinelena*