### PR TITLE
Add benchmark for model evaluation on small clusters

### DIFF
--- a/docs/source/user_guide/benchmarks/clusters.rst
+++ b/docs/source/user_guide/benchmarks/clusters.rst
@@ -8,40 +8,65 @@ Cluster Forces
 Summary
 -------
 
-Performance in predicting forces on fixed geometries of neutral atomistic clusters
-containing three to eight atoms.
+Performance in predicting forces on neutral atomistic clusters containing three to eight
+atoms where the chemical elements are chosen randomly. This benchmark is designed to
+test the universality and generalizability of the interatomic potentials.
 
 Metrics
 -------
 
-1. Force MAE by cluster size
+1. MAD2 force MAE by cluster size
 
 Mean absolute error (MAE) of force components across all atoms and clusters,
 reported separately for clusters containing three, four, five, six, seven, and eight
-atoms.
+atoms. Each model is compared to the ``mad2_forces`` reference values.
 
-Each model is compared to the reference force array most appropriate for its training
-domain. Models trained on broad atomistic datasets, or primarily on materials, are
-compared to ``mad2_forces``. Models focused on organic chemistry are compared to
-``omol25_forces``.
+2. OMol25 force MAE by cluster size
 
-For OMOL25-routed calculations, all clusters are evaluated with ``charge=0`` and
+Mean absolute error (MAE) of force components across all atoms and clusters,
+reported separately for clusters containing three, four, five, six, seven, and eight
+atoms. Each model is compared to the ``omol25_forces`` reference values.
+
+For all calculations, clusters are evaluated with ``charge=0`` and either
 ``spin_multiplicity=1`` for clusters with an even number of electrons or
 ``spin_multiplicity=2`` for clusters with an odd number of electrons.
 
 Computational cost
 ------------------
 
-High: tests evaluate 60,000 clusters per model and are likely to take hours on CPU.
+Medium: tests evaluate 60,000 small clusters per model and are expected to take less
+than an hour locally.
 
 Data availability
 -----------------
 
-Input/reference data:
+Cluster structures and reference forces are distributed as a separate zip archive and
+downloaded on-demand from the ML-PEG data store. The calculation script uses the
+public ML-PEG S3 bucket to retrieve these inputs.
 
-* Cluster structures and reference forces are distributed as a separate zip archive and
-  downloaded on-demand from the ML-PEG data store. The calculation script uses the
-  public ML-PEG S3 bucket to retrieve these inputs.
-* The extended XYZ input contains both ``mad2_forces`` and ``omol25_forces`` reference
-  arrays. Structures with non-finite values in the routed reference array did not
-  converge at that level of theory and they are therefore excluded from the metric.
+The structures are randomly generated neutral clusters ("n-mers") containing three
+to eight atoms. There are 10,000 clusters for each size from three to eight atoms,
+inclusive. Atoms were placed randomly while enforcing all pairwise interatomic distances
+to lie between 2.0 and 2.5 Å; element identities were sampled randomly from the 18
+elements of the first three rows of the periodic table.
+  
+The extended XYZ input contains both ``mad2_forces`` and ``omol25_forces`` reference
+arrays. Non-finite reference or predicted force components are excluded from the
+evaluation of the corresponding metric. These correspond to non-converged DFT
+calculations and/or model failures in the prediction (for example, due to
+unsupported chemical elements).
+
+Reference labels:
+
+* ``mad2_forces``: r2SCAN reference forces calculated with FHI-AIMS, using settings
+  consistent with the MAD-1.5 dataset.
+* ``omol25_forces``: ``ωB97M-V/def2-TZVPD`` reference forces calculated with ORCA,
+  using settings consistent with the OMol25 dataset. OMol-style DFT calculations used
+  total charge zero and spin multiplicities of 1 for even-electron clusters or 2 for
+  odd-electron clusters.
+
+In both cases, energies and forces were set to ``NaN`` in the rare cases where the DFT
+calculation did not converge.
+
+Further details on the motivation for n-mer benchmarks of universal MLIPs are
+available at https://doi.org/10.1063/5.0303302.

--- a/docs/source/user_guide/benchmarks/clusters.rst
+++ b/docs/source/user_guide/benchmarks/clusters.rst
@@ -34,8 +34,9 @@ For all calculations, clusters are evaluated with ``charge=0`` and either
 Computational cost
 ------------------
 
-Medium: tests evaluate 60,000 small clusters per model and are expected to take less
-than an hour locally.
+Medium: these tests evaluate 60,000 small clusters per model. They are expected to take
+on the order of minutes on a GPU.
+
 
 Data availability
 -----------------

--- a/docs/source/user_guide/benchmarks/clusters.rst
+++ b/docs/source/user_guide/benchmarks/clusters.rst
@@ -1,0 +1,47 @@
+========
+Clusters
+========
+
+Cluster Forces
+==============
+
+Summary
+-------
+
+Performance in predicting forces on fixed geometries of neutral atomistic clusters
+containing three to eight atoms.
+
+Metrics
+-------
+
+1. Force MAE by cluster size
+
+Mean absolute error (MAE) of force components across all atoms and clusters,
+reported separately for clusters containing three, four, five, six, seven, and eight
+atoms.
+
+Each model is compared to the reference force array most appropriate for its training
+domain. Models trained on broad atomistic datasets, or primarily on materials, are
+compared to ``mad2_forces``. Models focused on organic chemistry are compared to
+``omol25_forces``.
+
+For OMOL25-routed calculations, all clusters are evaluated with ``charge=0`` and
+``spin_multiplicity=1`` for clusters with an even number of electrons or
+``spin_multiplicity=2`` for clusters with an odd number of electrons.
+
+Computational cost
+------------------
+
+High: tests evaluate 60,000 clusters per model and are likely to take hours on CPU.
+
+Data availability
+-----------------
+
+Input/reference data:
+
+* Cluster structures and reference forces are distributed as a separate zip archive and
+  downloaded on-demand from the ML-PEG data store. The calculation script uses the
+  public ML-PEG S3 bucket to retrieve these inputs.
+* The extended XYZ input contains both ``mad2_forces`` and ``omol25_forces`` reference
+  arrays. Structures with non-finite values in the routed reference array did not
+  converge at that level of theory and they are therefore excluded from the metric.

--- a/docs/source/user_guide/benchmarks/clusters.rst
+++ b/docs/source/user_guide/benchmarks/clusters.rst
@@ -49,7 +49,7 @@ to eight atoms. There are 10,000 clusters for each size from three to eight atom
 inclusive. Atoms were placed randomly while enforcing all pairwise interatomic distances
 to lie between 2.0 and 2.5 Å; element identities were sampled randomly from the 18
 elements of the first three rows of the periodic table.
-  
+
 The extended XYZ input contains both ``mad2_forces`` and ``omol25_forces`` reference
 arrays. Non-finite reference or predicted force components are excluded from the
 evaluation of the corresponding metric. These correspond to non-converged DFT

--- a/docs/source/user_guide/benchmarks/clusters.rst
+++ b/docs/source/user_guide/benchmarks/clusters.rst
@@ -31,6 +31,12 @@ For all calculations, clusters are evaluated with ``charge=0`` and either
 ``spin_multiplicity=1`` for clusters with an even number of electrons or
 ``spin_multiplicity=2`` for clusters with an odd number of electrons.
 
+For models whose training data do not include dispersion, results are shown for both
+the native model and the model with the configured runtime dispersion correction. The
+corrected variant is identified by a suffix such as ``-D3`` and contributes to the
+category and overall scores. Models trained with dispersion already included are shown
+once, without an additional correction.
+
 Computational cost
 ------------------
 

--- a/docs/source/user_guide/benchmarks/index.rst
+++ b/docs/source/user_guide/benchmarks/index.rst
@@ -12,6 +12,7 @@ Benchmarks
     molecular_crystal
     molecular
     bulk_crystal
+    clusters
     lanthanides
     non_covalent_interactions
     tm_complexes

--- a/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
+++ b/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
@@ -3,14 +3,19 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 from ase.atoms import Atoms
-from ase.io import read
+from ase.io import read, write
 import numpy as np
 import pytest
 
 from ml_peg.analysis.utils.decorators import build_table, plot_density_scatter
-from ml_peg.analysis.utils.utils import load_metrics_config, mae
+from ml_peg.analysis.utils.utils import (
+    load_metrics_config,
+    mae,
+    sample_density_grid,
+)
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
 from ml_peg.models import current_models
@@ -30,37 +35,30 @@ DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
 )
 
 
-def _metric_name(cluster_size: int) -> str:
-    """
-    Return the metric name for a cluster size.
+REFERENCES = (
+    {
+        "key": "mad2",
+        "label": "MAD2",
+        "force_key": "mad2_ref_forces",
+        "level_of_theory": "r2SCAN",
+    },
+    {
+        "key": "omol25",
+        "label": "OMOL25",
+        "force_key": "omol25_ref_forces",
+        "level_of_theory": "ωB97M-V/def2-TZVPD",
+    },
+)
+PRED_FORCES_KEY = "pred_forces"
 
-    Parameters
-    ----------
-    cluster_size
-        Number of atoms in the cluster.
 
-    Returns
-    -------
-    str
-        Metric label.
-    """
-    return f"Force MAE ({cluster_size} atoms)"
+def _metric_name(reference: dict[str, str], cluster_size: int) -> str:
+    # build metric names consistently with metrics.yml and the app
+    return f"{reference['label']} Force MAE ({cluster_size} atoms)"
 
 
 def _load_structs(model: str) -> list[Atoms] | None:
-    """
-    Load evaluated clusters for a model.
-
-    Parameters
-    ----------
-    model
-        Model identifier.
-
-    Returns
-    -------
-    list[ase.atoms.Atoms] | None
-        Evaluated clusters, or ``None`` when no output exists.
-    """
+    # load evaluated clusters for a model, if present
     path = CALC_PATH / model / BENCHMARK_FILENAME
     if not path.exists():
         return None
@@ -70,49 +68,8 @@ def _load_structs(model: str) -> list[Atoms] | None:
     return structs
 
 
-def _forces(structs: list[Atoms]) -> tuple[np.ndarray, np.ndarray]:
-    """
-    Extract flattened reference and predicted force components.
-
-    Parameters
-    ----------
-    structs
-        Evaluated clusters.
-
-    Returns
-    -------
-    tuple[numpy.ndarray, numpy.ndarray]
-        Flattened reference and predicted force components.
-    """
-    ref = np.concatenate(
-        [
-            np.asarray(atoms.arrays["ref_forces"], dtype=float).reshape(-1)
-            for atoms in structs
-        ]
-    )
-    pred = np.concatenate(
-        [
-            np.asarray(atoms.arrays["pred_forces"], dtype=float).reshape(-1)
-            for atoms in structs
-        ]
-    )
-    return ref, pred
-
-
 def _group_by_cluster_size(structs: list[Atoms]) -> dict[int, list[Atoms]]:
-    """
-    Group evaluated clusters by atom count.
-
-    Parameters
-    ----------
-    structs
-        Evaluated clusters.
-
-    Returns
-    -------
-    dict[int, list[ase.atoms.Atoms]]
-        Clusters grouped by number of atoms.
-    """
+    # group evaluated clusters by atom count
     grouped: dict[int, list[Atoms]] = {size: [] for size in CLUSTER_SIZES}
     for atoms in structs:
         cluster_size = len(atoms)
@@ -121,153 +78,220 @@ def _group_by_cluster_size(structs: list[Atoms]) -> dict[int, list[Atoms]]:
     return grouped
 
 
+def _force_components(
+    structs: list[Atoms],
+    reference: dict[str, str],
+) -> tuple[np.ndarray, np.ndarray, list[Atoms], int]:
+    # extract finite force components and remember source structures for plotting
+    ref_components: list[np.ndarray] = []
+    pred_components: list[np.ndarray] = []
+    component_structs: list[Atoms] = []
+    excluded_components = 0
+
+    for atoms in structs:
+        ref_forces = np.asarray(atoms.arrays[reference["force_key"]], dtype=float)
+        ref_flat = ref_forces.reshape(-1)
+        pred_flat = np.asarray(atoms.arrays[PRED_FORCES_KEY], dtype=float).reshape(-1)
+        finite_mask = np.isfinite(ref_flat) & np.isfinite(pred_flat)
+
+        excluded_components += int((~finite_mask).sum())
+        if not finite_mask.any():
+            continue
+
+        ref_components.append(ref_flat[finite_mask])
+        pred_components.append(pred_flat[finite_mask])
+        component_structs.extend([atoms] * int(finite_mask.sum()))
+
+    if not ref_components:
+        return np.array([]), np.array([]), [], excluded_components
+
+    return (
+        np.concatenate(ref_components),
+        np.concatenate(pred_components),
+        component_structs,
+        excluded_components,
+    )
+
+
+def _write_density_trajectories(
+    *,
+    ref_vals: np.ndarray,
+    pred_vals: np.ndarray,
+    component_structs: list[Atoms],
+    traj_dir: Path,
+) -> None:
+    # write one extxyz trajectory per sampled density point for structure viewing
+    if len(ref_vals) == 0 or len(pred_vals) == 0:
+        return
+
+    _, _, sampled_mapping = sample_density_grid(ref_vals, pred_vals)
+    traj_dir.mkdir(parents=True, exist_ok=True)
+    for point_idx, source_indices in enumerate(sampled_mapping):
+        frames = [component_structs[source_idx] for source_idx in source_indices]
+        write(traj_dir / f"{point_idx}.extxyz", frames)
+
+
 @pytest.fixture
-def force_data() -> dict[str, dict[int, dict[str, object]]]:
+def force_data() -> dict[str, dict[str, dict[int, dict[str, Any]]]]:
     """
-    Load force components for all available model outputs, split by cluster size.
+    Load force components for all available model outputs.
 
     Returns
     -------
-    dict[str, dict[int, dict[str, object]]]
-        Mapping from model name and cluster size to flattened force arrays and metadata.
+    dict[str, dict[str, dict[int, dict[str, Any]]]]
+        Mapping from model name, reference key, and cluster size to force arrays and
+        metadata.
     """
-    results: dict[str, dict[int, dict[str, object]]] = {}
+    results: dict[str, dict[str, dict[int, dict[str, Any]]]] = {}
     for model in MODELS:
         structs = _load_structs(model)
         if structs is None:
             continue
 
-        model_results: dict[int, dict[str, object]] = {}
-        for cluster_size, grouped_structs in _group_by_cluster_size(structs).items():
-            if not grouped_structs:
-                continue
+        grouped_structs = _group_by_cluster_size(structs)
+        model_results: dict[str, dict[int, dict[str, Any]]] = {
+            reference["key"]: {} for reference in REFERENCES
+        }
+        for reference in REFERENCES:
+            for cluster_size, structs_for_size in grouped_structs.items():
+                if not structs_for_size:
+                    continue
 
-            ref, pred = _forces(grouped_structs)
-            reference_targets = sorted(
-                {
-                    str(atoms.info.get("reference_target", "unknown"))
-                    for atoms in grouped_structs
+                ref, pred, component_structs, excluded_components = _force_components(
+                    structs_for_size, reference
+                )
+                if ref.size == 0:
+                    continue
+
+                model_results[reference["key"]][cluster_size] = {
+                    "ref": ref,
+                    "pred": pred,
+                    "component_structs": component_structs,
+                    "excluded_components": excluded_components,
+                    "n_clusters": len(structs_for_size),
+                    "n_components": int(ref.size),
+                    "reference": reference["label"],
+                    "level_of_theory": reference["level_of_theory"],
                 }
-            )
-            model_results[cluster_size] = {
-                "ref": ref,
-                "pred": pred,
-                "reference_target": ", ".join(reference_targets),
-                "n_clusters": len(grouped_structs),
-                "n_components": int(ref.size),
-                "cluster_size": cluster_size,
-            }
-        if model_results:
+
+        if any(model_results[reference["key"]] for reference in REFERENCES):
             results[model] = model_results
     return results
 
 
 @pytest.fixture
 def force_mae(
-    force_data: dict[str, dict[int, dict[str, object]]],
+    force_data: dict[str, dict[str, dict[int, dict[str, Any]]]],
 ) -> dict[str, dict[str, float]]:
     """
-    Calculate component-wise force MAE by cluster size for all available models.
+    Calculate component-wise force MAE by reference and cluster size.
 
     Parameters
     ----------
     force_data
-        Flattened force data by model and cluster size.
+        Flattened force data by model, reference, and cluster size.
 
     Returns
     -------
     dict[str, dict[str, float]]
-        Force MAE by cluster-size metric and model.
+        Force MAE by metric and model.
     """
-    results = {_metric_name(size): {} for size in CLUSTER_SIZES}
+    results = {
+        _metric_name(reference, size): {}
+        for reference in REFERENCES
+        for size in CLUSTER_SIZES
+    }
     for model, model_data in force_data.items():
-        for cluster_size, data in model_data.items():
-            results[_metric_name(cluster_size)][model] = mae(data["ref"], data["pred"])
+        for reference in REFERENCES:
+            for cluster_size, data in model_data.get(reference["key"], {}).items():
+                results[_metric_name(reference, cluster_size)][model] = float(
+                    mae(data["ref"], data["pred"])
+                )
     return results
 
 
 def _write_force_parity_plot(
+    reference: dict[str, str],
     cluster_size: int,
-    force_data: dict[str, dict[int, dict[str, object]]],
+    force_data: dict[str, dict[str, dict[int, dict[str, Any]]]],
 ) -> dict[str, dict]:
-    """
-    Write force parity data for a cluster size.
-
-    Parameters
-    ----------
-    cluster_size
-        Number of atoms in the clusters to plot.
-    force_data
-        Flattened force data by model and cluster size.
-
-    Returns
-    -------
-    dict[str, dict]
-        Density-scatter input by model for the requested cluster size.
-    """
-    data_for_size = {
-        model: model_data[cluster_size]
+    # write force parity plot data and sampled structure trajectories
+    data_for_plot = {
+        model: model_data[reference["key"]][cluster_size]
         for model, model_data in force_data.items()
-        if cluster_size in model_data
+        if cluster_size in model_data.get(reference["key"], {})
     }
 
     @plot_density_scatter(
-        filename=OUT_PATH / f"figure_force_parity_{cluster_size}mer.json",
-        title=f"{cluster_size}-atom cluster force components",
+        filename=OUT_PATH
+        / f"figure_force_parity_{reference['key']}_{cluster_size}atoms.json",
+        title=f"{reference['label']} {cluster_size}-atom cluster force components",
         x_label="Reference force / (eV/A)",
         y_label="Predicted force / (eV/A)",
         annotation_metadata={
-            "reference_target": "Reference",
+            "level_of_theory": "Level",
             "n_clusters": "Clusters",
             "n_components": "Components",
+            "excluded_components": "Excluded components",
         },
     )
     def plot() -> dict[str, dict]:
-        """
-        Build density-scatter input for the requested cluster size.
-
-        Returns
-        -------
-        dict[str, dict]
-            Density-scatter input by model.
-        """
+        # build density-scatter input
         return {
             model: {
                 "ref": data["ref"],
                 "pred": data["pred"],
                 "meta": {
-                    "reference_target": data["reference_target"],
+                    "level_of_theory": data["level_of_theory"],
                     "n_clusters": data["n_clusters"],
                     "n_components": data["n_components"],
+                    "excluded_components": data["excluded_components"],
                 },
             }
-            for model, data in data_for_size.items()
+            for model, data in data_for_plot.items()
         }
+
+    for model, data in data_for_plot.items():
+        _write_density_trajectories(
+            ref_vals=data["ref"],
+            pred_vals=data["pred"],
+            component_structs=data["component_structs"],
+            traj_dir=OUT_PATH
+            / model
+            / "density_traj"
+            / f"{reference['key']}_{cluster_size}atoms",
+        )
 
     return plot()
 
 
 @pytest.fixture
 def force_parity_plots(
-    force_data: dict[str, dict[int, dict[str, object]]],
-) -> dict[int, dict[str, dict]]:
+    force_data: dict[str, dict[str, dict[int, dict[str, Any]]]],
+) -> dict[str, dict[str, dict]]:
     """
-    Write force parity plots for each cluster size.
+    Write force parity plots for each reference and cluster size.
 
     Parameters
     ----------
     force_data
-        Flattened force data by model and cluster size.
+        Flattened force data by model, reference, and cluster size.
 
     Returns
     -------
-    dict[int, dict[str, dict]]
-        Plot input data by cluster size.
+    dict[str, dict[str, dict]]
+        Plot input data by metric name.
     """
     return {
-        cluster_size: _write_force_parity_plot(cluster_size, force_data)
+        _metric_name(reference, cluster_size): _write_force_parity_plot(
+            reference, cluster_size, force_data
+        )
+        for reference in REFERENCES
         for cluster_size in CLUSTER_SIZES
-        if any(cluster_size in model_data for model_data in force_data.values())
+        if any(
+            cluster_size in model_data.get(reference["key"], {})
+            for model_data in force_data.values()
+        )
     }
 
 
@@ -280,7 +304,7 @@ def force_parity_plots(
 )
 def metrics(
     force_mae: dict[str, dict[str, float]],
-    force_parity_plots: dict[int, dict[str, dict]],
+    force_parity_plots: dict[str, dict[str, dict]],
 ) -> dict[str, dict]:
     """
     Build the benchmark table JSON.
@@ -288,7 +312,7 @@ def metrics(
     Parameters
     ----------
     force_mae
-        Component-wise force MAE by cluster-size metric and model.
+        Component-wise force MAE by metric and model.
     force_parity_plots
         Force parity plot data; included to ensure the figures are written.
 

--- a/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
+++ b/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
@@ -321,7 +321,7 @@ def _write_force_parity_plot(
             "level_of_theory": "Level",
             "n_clusters": "Clusters",
             "n_components": "Components",
-            "excluded_components": "Excluded components",
+            "excluded_components": "NaN force components",
         },
     )
     def plot() -> dict[str, dict]:

--- a/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
+++ b/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
@@ -12,6 +12,7 @@ import pytest
 
 from ml_peg.analysis.utils.decorators import build_table, plot_density_scatter
 from ml_peg.analysis.utils.utils import (
+    get_struct_info,
     load_metrics_config,
     mae,
     sample_density_grid,
@@ -34,6 +35,13 @@ DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
     METRICS_CONFIG_PATH
 )
 
+INFO = get_struct_info(
+    calc_path=CALC_PATH,
+    glob_pattern=BENCHMARK_FILENAME,
+    write_info=True,
+    write_structs=False,
+    out_path=OUT_PATH,
+)
 
 REFERENCES = (
     {
@@ -53,12 +61,38 @@ PRED_FORCES_KEY = "pred_forces"
 
 
 def _metric_name(reference: dict[str, str], cluster_size: int) -> str:
-    # build metric names consistently with metrics.yml and the app
+    """
+    Build a metric name.
+
+    Parameters
+    ----------
+    reference
+        Reference metadata.
+    cluster_size
+        Number of atoms in the cluster.
+
+    Returns
+    -------
+    str
+        Metric name.
+    """
     return f"{reference['label']} Force MAE ({cluster_size} atoms)"
 
 
 def _load_structs(model: str) -> list[Atoms] | None:
-    # load evaluated clusters for a model, if present
+    """
+    Load evaluated clusters for a model.
+
+    Parameters
+    ----------
+    model
+        Model name.
+
+    Returns
+    -------
+    list[Atoms] | None
+        Evaluated clusters, or None when no output exists.
+    """
     path = CALC_PATH / model / BENCHMARK_FILENAME
     if not path.exists():
         return None
@@ -69,7 +103,19 @@ def _load_structs(model: str) -> list[Atoms] | None:
 
 
 def _group_by_cluster_size(structs: list[Atoms]) -> dict[int, list[Atoms]]:
-    # group evaluated clusters by atom count
+    """
+    Group evaluated clusters by atom count.
+
+    Parameters
+    ----------
+    structs
+        Evaluated clusters.
+
+    Returns
+    -------
+    dict[int, list[Atoms]]
+        Structures keyed by cluster size.
+    """
     grouped: dict[int, list[Atoms]] = {size: [] for size in CLUSTER_SIZES}
     for atoms in structs:
         cluster_size = len(atoms)
@@ -82,7 +128,21 @@ def _force_components(
     structs: list[Atoms],
     reference: dict[str, str],
 ) -> tuple[np.ndarray, np.ndarray, list[Atoms], int]:
-    # extract finite force components and remember source structures for plotting
+    """
+    Extract finite force components.
+
+    Parameters
+    ----------
+    structs
+        Evaluated clusters.
+    reference
+        Reference metadata.
+
+    Returns
+    -------
+    tuple[np.ndarray, np.ndarray, list[Atoms], int]
+        Reference components, predictions, source structures, and excluded count.
+    """
     ref_components: list[np.ndarray] = []
     pred_components: list[np.ndarray] = []
     component_structs: list[Atoms] = []
@@ -120,7 +180,20 @@ def _write_density_trajectories(
     component_structs: list[Atoms],
     traj_dir: Path,
 ) -> None:
-    # write one extxyz trajectory per sampled density point for structure viewing
+    """
+    Write sampled density-point trajectories.
+
+    Parameters
+    ----------
+    ref_vals
+        Reference force components.
+    pred_vals
+        Predicted force components.
+    component_structs
+        Source structures for each force component.
+    traj_dir
+        Output trajectory directory.
+    """
     if len(ref_vals) == 0 or len(pred_vals) == 0:
         return
 
@@ -215,7 +288,23 @@ def _write_force_parity_plot(
     cluster_size: int,
     force_data: dict[str, dict[str, dict[int, dict[str, Any]]]],
 ) -> dict[str, dict]:
-    # write force parity plot data and sampled structure trajectories
+    """
+    Write force parity plot data.
+
+    Parameters
+    ----------
+    reference
+        Reference metadata.
+    cluster_size
+        Number of atoms in the cluster.
+    force_data
+        Force components by model, reference, and cluster size.
+
+    Returns
+    -------
+    dict[str, dict]
+        Plot input data.
+    """
     data_for_plot = {
         model: model_data[reference["key"]][cluster_size]
         for model, model_data in force_data.items()
@@ -236,7 +325,14 @@ def _write_force_parity_plot(
         },
     )
     def plot() -> dict[str, dict]:
-        # build density-scatter input
+        """
+        Build density-scatter input.
+
+        Returns
+        -------
+        dict[str, dict]
+            Plot input data.
+        """
         return {
             model: {
                 "ref": data["ref"],

--- a/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
+++ b/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
@@ -1,0 +1,312 @@
+"""Analyse small-cluster force predictions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ase.atoms import Atoms
+from ase.io import read
+import numpy as np
+import pytest
+
+from ml_peg.analysis.utils.decorators import build_table, plot_density_scatter
+from ml_peg.analysis.utils.utils import load_metrics_config, mae
+from ml_peg.app import APP_ROOT
+from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
+from ml_peg.models.get_models import get_model_names
+
+MODELS = get_model_names(current_models)
+
+BENCHMARK_DIR = "cluster_forces"
+BENCHMARK_FILENAME = "cluster_forces.extxyz"
+CLUSTER_SIZES = (3, 4, 5, 6, 7, 8)
+CALC_PATH = CALCS_ROOT / "clusters" / BENCHMARK_DIR / "outputs"
+OUT_PATH = APP_ROOT / "data" / "clusters" / BENCHMARK_DIR
+
+METRICS_CONFIG_PATH = Path(__file__).with_name("metrics.yml")
+DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
+    METRICS_CONFIG_PATH
+)
+
+
+def _metric_name(cluster_size: int) -> str:
+    """
+    Return the metric name for a cluster size.
+
+    Parameters
+    ----------
+    cluster_size
+        Number of atoms in the cluster.
+
+    Returns
+    -------
+    str
+        Metric label.
+    """
+    return f"Force MAE ({cluster_size} atoms)"
+
+
+def _load_structs(model: str) -> list[Atoms] | None:
+    """
+    Load evaluated clusters for a model.
+
+    Parameters
+    ----------
+    model
+        Model identifier.
+
+    Returns
+    -------
+    list[ase.atoms.Atoms] | None
+        Evaluated clusters, or ``None`` when no output exists.
+    """
+    path = CALC_PATH / model / BENCHMARK_FILENAME
+    if not path.exists():
+        return None
+    structs = read(path, index=":")
+    if not isinstance(structs, list) or not structs:
+        raise ValueError(f"Unexpected output content: {path}")
+    return structs
+
+
+def _forces(structs: list[Atoms]) -> tuple[np.ndarray, np.ndarray]:
+    """
+    Extract flattened reference and predicted force components.
+
+    Parameters
+    ----------
+    structs
+        Evaluated clusters.
+
+    Returns
+    -------
+    tuple[numpy.ndarray, numpy.ndarray]
+        Flattened reference and predicted force components.
+    """
+    ref = np.concatenate(
+        [
+            np.asarray(atoms.arrays["ref_forces"], dtype=float).reshape(-1)
+            for atoms in structs
+        ]
+    )
+    pred = np.concatenate(
+        [
+            np.asarray(atoms.arrays["pred_forces"], dtype=float).reshape(-1)
+            for atoms in structs
+        ]
+    )
+    return ref, pred
+
+
+def _group_by_cluster_size(structs: list[Atoms]) -> dict[int, list[Atoms]]:
+    """
+    Group evaluated clusters by atom count.
+
+    Parameters
+    ----------
+    structs
+        Evaluated clusters.
+
+    Returns
+    -------
+    dict[int, list[ase.atoms.Atoms]]
+        Clusters grouped by number of atoms.
+    """
+    grouped: dict[int, list[Atoms]] = {size: [] for size in CLUSTER_SIZES}
+    for atoms in structs:
+        cluster_size = len(atoms)
+        if cluster_size in grouped:
+            grouped[cluster_size].append(atoms)
+    return grouped
+
+
+@pytest.fixture
+def force_data() -> dict[str, dict[int, dict[str, object]]]:
+    """
+    Load force components for all available model outputs, split by cluster size.
+
+    Returns
+    -------
+    dict[str, dict[int, dict[str, object]]]
+        Mapping from model name and cluster size to flattened force arrays and metadata.
+    """
+    results: dict[str, dict[int, dict[str, object]]] = {}
+    for model in MODELS:
+        structs = _load_structs(model)
+        if structs is None:
+            continue
+
+        model_results: dict[int, dict[str, object]] = {}
+        for cluster_size, grouped_structs in _group_by_cluster_size(structs).items():
+            if not grouped_structs:
+                continue
+
+            ref, pred = _forces(grouped_structs)
+            reference_targets = sorted(
+                {
+                    str(atoms.info.get("reference_target", "unknown"))
+                    for atoms in grouped_structs
+                }
+            )
+            model_results[cluster_size] = {
+                "ref": ref,
+                "pred": pred,
+                "reference_target": ", ".join(reference_targets),
+                "n_clusters": len(grouped_structs),
+                "n_components": int(ref.size),
+                "cluster_size": cluster_size,
+            }
+        if model_results:
+            results[model] = model_results
+    return results
+
+
+@pytest.fixture
+def force_mae(
+    force_data: dict[str, dict[int, dict[str, object]]],
+) -> dict[str, dict[str, float]]:
+    """
+    Calculate component-wise force MAE by cluster size for all available models.
+
+    Parameters
+    ----------
+    force_data
+        Flattened force data by model and cluster size.
+
+    Returns
+    -------
+    dict[str, dict[str, float]]
+        Force MAE by cluster-size metric and model.
+    """
+    results = {_metric_name(size): {} for size in CLUSTER_SIZES}
+    for model, model_data in force_data.items():
+        for cluster_size, data in model_data.items():
+            results[_metric_name(cluster_size)][model] = mae(data["ref"], data["pred"])
+    return results
+
+
+def _write_force_parity_plot(
+    cluster_size: int,
+    force_data: dict[str, dict[int, dict[str, object]]],
+) -> dict[str, dict]:
+    """
+    Write force parity data for a cluster size.
+
+    Parameters
+    ----------
+    cluster_size
+        Number of atoms in the clusters to plot.
+    force_data
+        Flattened force data by model and cluster size.
+
+    Returns
+    -------
+    dict[str, dict]
+        Density-scatter input by model for the requested cluster size.
+    """
+    data_for_size = {
+        model: model_data[cluster_size]
+        for model, model_data in force_data.items()
+        if cluster_size in model_data
+    }
+
+    @plot_density_scatter(
+        filename=OUT_PATH / f"figure_force_parity_{cluster_size}mer.json",
+        title=f"{cluster_size}-atom cluster force components",
+        x_label="Reference force / (eV/A)",
+        y_label="Predicted force / (eV/A)",
+        annotation_metadata={
+            "reference_target": "Reference",
+            "n_clusters": "Clusters",
+            "n_components": "Components",
+        },
+    )
+    def plot() -> dict[str, dict]:
+        """
+        Build density-scatter input for the requested cluster size.
+
+        Returns
+        -------
+        dict[str, dict]
+            Density-scatter input by model.
+        """
+        return {
+            model: {
+                "ref": data["ref"],
+                "pred": data["pred"],
+                "meta": {
+                    "reference_target": data["reference_target"],
+                    "n_clusters": data["n_clusters"],
+                    "n_components": data["n_components"],
+                },
+            }
+            for model, data in data_for_size.items()
+        }
+
+    return plot()
+
+
+@pytest.fixture
+def force_parity_plots(
+    force_data: dict[str, dict[int, dict[str, object]]],
+) -> dict[int, dict[str, dict]]:
+    """
+    Write force parity plots for each cluster size.
+
+    Parameters
+    ----------
+    force_data
+        Flattened force data by model and cluster size.
+
+    Returns
+    -------
+    dict[int, dict[str, dict]]
+        Plot input data by cluster size.
+    """
+    return {
+        cluster_size: _write_force_parity_plot(cluster_size, force_data)
+        for cluster_size in CLUSTER_SIZES
+        if any(cluster_size in model_data for model_data in force_data.values())
+    }
+
+
+@pytest.fixture
+@build_table(
+    filename=OUT_PATH / "cluster_forces_metrics_table.json",
+    metric_tooltips=DEFAULT_TOOLTIPS,
+    thresholds=DEFAULT_THRESHOLDS,
+    weights=DEFAULT_WEIGHTS,
+)
+def metrics(
+    force_mae: dict[str, dict[str, float]],
+    force_parity_plots: dict[int, dict[str, dict]],
+) -> dict[str, dict]:
+    """
+    Build the benchmark table JSON.
+
+    Parameters
+    ----------
+    force_mae
+        Component-wise force MAE by cluster-size metric and model.
+    force_parity_plots
+        Force parity plot data; included to ensure the figures are written.
+
+    Returns
+    -------
+    dict[str, dict]
+        Metric names and values for all models.
+    """
+    return force_mae
+
+
+def test_cluster_forces(metrics: dict[str, dict]) -> None:
+    """
+    Run analysis for the cluster-force benchmark.
+
+    Parameters
+    ----------
+    metrics
+        Benchmark metrics table.
+    """
+    return

--- a/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
+++ b/ml_peg/analysis/clusters/cluster_forces/analyse_cluster_forces.py
@@ -12,6 +12,7 @@ import pytest
 
 from ml_peg.analysis.utils.decorators import build_table, plot_density_scatter
 from ml_peg.analysis.utils.utils import (
+    build_dispersion_name_map,
     get_struct_info,
     load_metrics_config,
     mae,
@@ -23,6 +24,11 @@ from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
 
 MODELS = get_model_names(current_models)
+DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)
+MODEL_VARIANTS = {
+    dispersion_name: model for model, dispersion_name in DISPERSION_NAME_MAP.items()
+}
+SUMMARY_MODEL_IDS = {model: DISPERSION_NAME_MAP.get(model, model) for model in MODELS}
 
 BENCHMARK_DIR = "cluster_forces"
 BENCHMARK_FILENAME = "cluster_forces.extxyz"
@@ -58,6 +64,7 @@ REFERENCES = (
     },
 )
 PRED_FORCES_KEY = "pred_forces"
+DISPERSION_PRED_FORCES_KEY = "dispersion_pred_forces"
 
 
 def _metric_name(reference: dict[str, str], cluster_size: int) -> str:
@@ -127,6 +134,7 @@ def _group_by_cluster_size(structs: list[Atoms]) -> dict[int, list[Atoms]]:
 def _force_components(
     structs: list[Atoms],
     reference: dict[str, str],
+    pred_forces_key: str,
 ) -> tuple[np.ndarray, np.ndarray, list[Atoms], int]:
     """
     Extract finite force components.
@@ -137,6 +145,8 @@ def _force_components(
         Evaluated clusters.
     reference
         Reference metadata.
+    pred_forces_key
+        Predicted-force array to evaluate.
 
     Returns
     -------
@@ -151,7 +161,7 @@ def _force_components(
     for atoms in structs:
         ref_forces = np.asarray(atoms.arrays[reference["force_key"]], dtype=float)
         ref_flat = ref_forces.reshape(-1)
-        pred_flat = np.asarray(atoms.arrays[PRED_FORCES_KEY], dtype=float).reshape(-1)
+        pred_flat = np.asarray(atoms.arrays[pred_forces_key], dtype=float).reshape(-1)
         finite_mask = np.isfinite(ref_flat) & np.isfinite(pred_flat)
 
         excluded_components += int((~finite_mask).sum())
@@ -222,33 +232,42 @@ def force_data() -> dict[str, dict[str, dict[int, dict[str, Any]]]]:
             continue
 
         grouped_structs = _group_by_cluster_size(structs)
-        model_results: dict[str, dict[int, dict[str, Any]]] = {
-            reference["key"]: {} for reference in REFERENCES
-        }
-        for reference in REFERENCES:
-            for cluster_size, structs_for_size in grouped_structs.items():
-                if not structs_for_size:
-                    continue
+        prediction_variants = [(model, PRED_FORCES_KEY)]
+        if model in DISPERSION_NAME_MAP and all(
+            DISPERSION_PRED_FORCES_KEY in atoms.arrays for atoms in structs
+        ):
+            prediction_variants.append(
+                (DISPERSION_NAME_MAP[model], DISPERSION_PRED_FORCES_KEY)
+            )
 
-                ref, pred, component_structs, excluded_components = _force_components(
-                    structs_for_size, reference
-                )
-                if ref.size == 0:
-                    continue
+        for variant_name, pred_forces_key in prediction_variants:
+            model_results: dict[str, dict[int, dict[str, Any]]] = {
+                reference["key"]: {} for reference in REFERENCES
+            }
+            for reference in REFERENCES:
+                for cluster_size, structs_for_size in grouped_structs.items():
+                    if not structs_for_size:
+                        continue
 
-                model_results[reference["key"]][cluster_size] = {
-                    "ref": ref,
-                    "pred": pred,
-                    "component_structs": component_structs,
-                    "excluded_components": excluded_components,
-                    "n_clusters": len(structs_for_size),
-                    "n_components": int(ref.size),
-                    "reference": reference["label"],
-                    "level_of_theory": reference["level_of_theory"],
-                }
+                    ref, pred, component_structs, excluded_components = (
+                        _force_components(structs_for_size, reference, pred_forces_key)
+                    )
+                    if ref.size == 0:
+                        continue
 
-        if any(model_results[reference["key"]] for reference in REFERENCES):
-            results[model] = model_results
+                    model_results[reference["key"]][cluster_size] = {
+                        "ref": ref,
+                        "pred": pred,
+                        "component_structs": component_structs,
+                        "excluded_components": excluded_components,
+                        "n_clusters": len(structs_for_size),
+                        "n_components": int(ref.size),
+                        "reference": reference["label"],
+                        "level_of_theory": reference["level_of_theory"],
+                    }
+
+            if any(model_results[reference["key"]] for reference in REFERENCES):
+                results[variant_name] = model_results
     return results
 
 
@@ -397,6 +416,8 @@ def force_parity_plots(
     metric_tooltips=DEFAULT_TOOLTIPS,
     thresholds=DEFAULT_THRESHOLDS,
     weights=DEFAULT_WEIGHTS,
+    model_variants=MODEL_VARIANTS,
+    summary_model_ids=SUMMARY_MODEL_IDS,
 )
 def metrics(
     force_mae: dict[str, dict[str, float]],

--- a/ml_peg/analysis/clusters/cluster_forces/metrics.yml
+++ b/ml_peg/analysis/clusters/cluster_forces/metrics.yml
@@ -1,43 +1,85 @@
 metrics:
-  Force MAE (3 atoms):
+  MAD2 Force MAE (3 atoms):
     good: 0.1
     bad: 1.0
     unit: eV/A
-    tooltip: "Component-wise force MAE on neutral 3-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
-    level_of_theory: null
+    tooltip: "Component-wise force MAE on neutral 3-atom clusters compared to r2SCAN reference forces calculated with FHI-AIMS using MAD-1.5-consistent settings."
+    level_of_theory: r2SCAN
     weight: 1
-  Force MAE (4 atoms):
+  MAD2 Force MAE (4 atoms):
     good: 0.1
     bad: 1.0
     unit: eV/A
-    tooltip: "Component-wise force MAE on neutral 4-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
-    level_of_theory: null
+    tooltip: "Component-wise force MAE on neutral 4-atom clusters compared to r2SCAN reference forces calculated with FHI-AIMS using MAD-1.5-consistent settings."
+    level_of_theory: r2SCAN
     weight: 1
-  Force MAE (5 atoms):
+  MAD2 Force MAE (5 atoms):
     good: 0.1
     bad: 1.0
     unit: eV/A
-    tooltip: "Component-wise force MAE on neutral 5-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
-    level_of_theory: null
+    tooltip: "Component-wise force MAE on neutral 5-atom clusters compared to r2SCAN reference forces calculated with FHI-AIMS using MAD-1.5-consistent settings."
+    level_of_theory: r2SCAN
     weight: 1
-  Force MAE (6 atoms):
+  MAD2 Force MAE (6 atoms):
     good: 0.1
     bad: 1.0
     unit: eV/A
-    tooltip: "Component-wise force MAE on neutral 6-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
-    level_of_theory: null
+    tooltip: "Component-wise force MAE on neutral 6-atom clusters compared to r2SCAN reference forces calculated with FHI-AIMS using MAD-1.5-consistent settings."
+    level_of_theory: r2SCAN
     weight: 1
-  Force MAE (7 atoms):
+  MAD2 Force MAE (7 atoms):
     good: 0.1
     bad: 1.0
     unit: eV/A
-    tooltip: "Component-wise force MAE on neutral 7-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
-    level_of_theory: null
+    tooltip: "Component-wise force MAE on neutral 7-atom clusters compared to r2SCAN reference forces calculated with FHI-AIMS using MAD-1.5-consistent settings."
+    level_of_theory: r2SCAN
     weight: 1
-  Force MAE (8 atoms):
+  MAD2 Force MAE (8 atoms):
     good: 0.1
     bad: 1.0
     unit: eV/A
-    tooltip: "Component-wise force MAE on neutral 8-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
-    level_of_theory: null
+    tooltip: "Component-wise force MAE on neutral 8-atom clusters compared to r2SCAN reference forces calculated with FHI-AIMS using MAD-1.5-consistent settings."
+    level_of_theory: r2SCAN
+    weight: 1
+  OMOL25 Force MAE (3 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 3-atom clusters compared to ωB97M-V/def2-TZVPD reference forces calculated with ORCA using OMol25-consistent settings."
+    level_of_theory: ωB97M-V/def2-TZVPD
+    weight: 1
+  OMOL25 Force MAE (4 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 4-atom clusters compared to ωB97M-V/def2-TZVPD reference forces calculated with ORCA using OMol25-consistent settings."
+    level_of_theory: ωB97M-V/def2-TZVPD
+    weight: 1
+  OMOL25 Force MAE (5 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 5-atom clusters compared to ωB97M-V/def2-TZVPD reference forces calculated with ORCA using OMol25-consistent settings."
+    level_of_theory: ωB97M-V/def2-TZVPD
+    weight: 1
+  OMOL25 Force MAE (6 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 6-atom clusters compared to ωB97M-V/def2-TZVPD reference forces calculated with ORCA using OMol25-consistent settings."
+    level_of_theory: ωB97M-V/def2-TZVPD
+    weight: 1
+  OMOL25 Force MAE (7 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 7-atom clusters compared to ωB97M-V/def2-TZVPD reference forces calculated with ORCA using OMol25-consistent settings."
+    level_of_theory: ωB97M-V/def2-TZVPD
+    weight: 1
+  OMOL25 Force MAE (8 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 8-atom clusters compared to ωB97M-V/def2-TZVPD reference forces calculated with ORCA using OMol25-consistent settings."
+    level_of_theory: ωB97M-V/def2-TZVPD
     weight: 1

--- a/ml_peg/analysis/clusters/cluster_forces/metrics.yml
+++ b/ml_peg/analysis/clusters/cluster_forces/metrics.yml
@@ -1,0 +1,43 @@
+metrics:
+  Force MAE (3 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 3-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
+    level_of_theory: null
+    weight: 1
+  Force MAE (4 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 4-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
+    level_of_theory: null
+    weight: 1
+  Force MAE (5 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 5-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
+    level_of_theory: null
+    weight: 1
+  Force MAE (6 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 6-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
+    level_of_theory: null
+    weight: 1
+  Force MAE (7 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 7-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
+    level_of_theory: null
+    weight: 1
+  Force MAE (8 atoms):
+    good: 0.1
+    bad: 1.0
+    unit: eV/A
+    tooltip: "Component-wise force MAE on neutral 8-atom clusters. Materials/general models are compared to MAD2 forces; organic-focused models are compared to OMOL25 forces."
+    level_of_theory: null
+    weight: 1

--- a/ml_peg/analysis/utils/decorators.py
+++ b/ml_peg/analysis/utils/decorators.py
@@ -1475,6 +1475,8 @@ def build_table(
     normalizer: Callable[[float, float, float], float] | None = None,
     weights: dict[str, float] | None = None,
     mlip_name_map: dict[str, str] | None = None,
+    model_variants: dict[str, str] | None = None,
+    summary_model_ids: dict[str, str] | None = None,
 ) -> Callable:
     """
     Build DataTable, including optional metric normalisation.
@@ -1504,6 +1506,12 @@ def build_table(
         Optional mapping of model identifier -> display name. Use this to annotate
         table rows (e.g. append a suffix) without changing the underlying model
         configuration metadata.
+    model_variants
+        Optional mapping of additional model variant identifiers to their registered
+        base model identifiers.
+    summary_model_ids
+        Optional mapping of registered model identifiers to the variant identifier
+        that should contribute to category and overall summaries.
 
     Returns
     -------
@@ -1576,7 +1584,23 @@ def build_table(
             metrics_columns = ("MLIP", "Score") + tuple(results)
 
             # Get all models (including those without results for this benchmark)
-            mlips = tuple(get_model_names())
+            registry_mlips = tuple(get_model_names())
+            variants = model_variants or {}
+            unknown_bases = set(variants.values()) - set(registry_mlips)
+            if unknown_bases:
+                raise KeyError(
+                    "Unknown base models for variants: "
+                    f"{', '.join(sorted(unknown_bases))}"
+                )
+            duplicate_ids = set(variants) & set(registry_mlips)
+            if duplicate_ids:
+                raise ValueError(
+                    "Model variant identifiers conflict with registered models: "
+                    f"{', '.join(sorted(duplicate_ids))}"
+                )
+
+            mlips = registry_mlips + tuple(variants)
+            base_models = {mlip: variants.get(mlip, mlip) for mlip in mlips}
 
             name_map = mlip_name_map if mlip_name_map else {}
             display_names = {mlip: name_map.get(mlip, mlip) for mlip in mlips}
@@ -1630,13 +1654,13 @@ def build_table(
                 tooltip_header=tooltip_header,
             )
 
-            model_configs, model_levels = load_model_configs(mlips)
+            model_configs, model_levels = load_model_configs(registry_mlips)
 
             model_configs = {
-                display_names[name]: config for name, config in model_configs.items()
+                display_names[name]: model_configs[base_models[name]] for name in mlips
             }
             model_levels = {
-                display_names[name]: level for name, level in model_levels.items()
+                display_names[name]: model_levels[base_models[name]] for name in mlips
             }
 
             # Extract metric level of theory from thresholds
@@ -1647,10 +1671,26 @@ def build_table(
                 )
 
             # Save dict of table to be loaded
-            model_name_map = {
-                display_name: original_name
-                for original_name, display_name in display_names.items()
+            model_name_map = {display_names[name]: base_models[name] for name in mlips}
+
+            preferred_summary_ids = summary_model_ids or {}
+            unknown_summary_models = set(preferred_summary_ids) - set(registry_mlips)
+            if unknown_summary_models:
+                raise KeyError(
+                    "Unknown models in summary_model_ids: "
+                    f"{', '.join(sorted(unknown_summary_models))}"
+                )
+            invalid_summary_ids = {
+                model: variant
+                for model, variant in preferred_summary_ids.items()
+                if variant not in base_models or base_models[variant] != model
             }
+            if invalid_summary_ids:
+                invalid = ", ".join(
+                    f"{model} -> {variant}"
+                    for model, variant in sorted(invalid_summary_ids.items())
+                )
+                raise ValueError(f"Invalid summary model variants: {invalid}")
 
             Path(filename).parent.mkdir(parents=True, exist_ok=True)
             with open(filename, "w") as fp:
@@ -1665,6 +1705,7 @@ def build_table(
                         "metric_levels_of_theory": metric_levels,
                         "model_configs": model_configs,
                         "model_name_map": model_name_map,
+                        "summary_model_ids": preferred_summary_ids,
                     },
                     fp,
                 )

--- a/ml_peg/app/build_app.py
+++ b/ml_peg/app/build_app.py
@@ -714,12 +714,16 @@ def build_summary_table(
         category_columns.append(category_col)
 
         table_name_map = getattr(table, "model_name_map", {}) or {}
+        summary_model_ids = getattr(table, "summary_model_ids", {}) or {}
         for row in table.data:
             # Category tables may include models not to be included
             # Table headings are of the form "[category] Score"
             # ``original_name`` refers to the original model identifier
             # (no display suffix)
             original_name = table_name_map.get(row["MLIP"], row["MLIP"])
+            preferred_id = summary_model_ids.get(original_name, original_name)
+            if row.get("id", original_name) != preferred_id:
+                continue
             if original_name in summary_data:
                 summary_data[original_name][category_col] = row["Score"]
 

--- a/ml_peg/app/clusters/cluster_forces/app_cluster_forces.py
+++ b/ml_peg/app/clusters/cluster_forces/app_cluster_forces.py
@@ -1,0 +1,80 @@
+"""Run app for the cluster-force benchmark."""
+
+from __future__ import annotations
+
+from dash import Dash
+from dash.html import Div
+
+from ml_peg.app import APP_ROOT
+from ml_peg.app.base_app import BaseApp
+from ml_peg.app.utils.build_callbacks import plot_from_table_column
+from ml_peg.app.utils.load import read_plot
+
+BENCHMARK_NAME = "Cluster Forces"
+DATA_PATH = APP_ROOT / "data" / "clusters" / "cluster_forces"
+CLUSTER_SIZES = (3, 4, 5, 6, 7, 8)
+
+
+def _metric_name(cluster_size: int) -> str:
+    """
+    Return the metric name for a cluster size.
+
+    Parameters
+    ----------
+    cluster_size
+        Number of atoms in the cluster.
+
+    Returns
+    -------
+    str
+        Metric label.
+    """
+    return f"Force MAE ({cluster_size} atoms)"
+
+
+class ClusterForcesApp(BaseApp):
+    """Cluster-force benchmark app layout and callbacks."""
+
+    def register_callbacks(self) -> None:
+        """Register force parity callbacks."""
+        column_to_plot = {
+            _metric_name(cluster_size): read_plot(
+                DATA_PATH / f"figure_force_parity_{cluster_size}mer.json",
+                id=f"{BENCHMARK_NAME}-{cluster_size}mer-force-parity-figure",
+            )
+            for cluster_size in CLUSTER_SIZES
+        }
+        plot_from_table_column(
+            table_id=self.table_id,
+            plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
+            column_to_plot=column_to_plot,
+        )
+
+
+def get_app() -> ClusterForcesApp:
+    """
+    Get cluster-force benchmark app.
+
+    Returns
+    -------
+    ClusterForcesApp
+        App instance.
+    """
+    return ClusterForcesApp(
+        name=BENCHMARK_NAME,
+        description=(
+            "Component-wise force MAE for neutral small clusters, split by cluster "
+            "size. Models are routed to MAD2 or OMOL25 reference forces according "
+            "to their training domain."
+        ),
+        table_path=DATA_PATH / "cluster_forces_metrics_table.json",
+        extra_components=[Div(id=f"{BENCHMARK_NAME}-figure-placeholder")],
+    )
+
+
+if __name__ == "__main__":
+    full_app = Dash(__name__, assets_folder=DATA_PATH.parent.parent)
+    benchmark_app = get_app()
+    full_app.layout = benchmark_app.layout
+    benchmark_app.register_callbacks()
+    full_app.run(port=8061, debug=True)

--- a/ml_peg/app/clusters/cluster_forces/app_cluster_forces.py
+++ b/ml_peg/app/clusters/cluster_forces/app_cluster_forces.py
@@ -15,8 +15,11 @@ from ml_peg.models.get_models import get_model_names
 MODELS = get_model_names(current_models)
 
 BENCHMARK_NAME = "Cluster Forces"
-DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/clusters.html#cluster-forces"
+DOCS_URL = (
+    "https://ddmms.github.io/ml-peg/user_guide/benchmarks/clusters.html#cluster-forces"
+)
 DATA_PATH = APP_ROOT / "data" / "clusters" / "cluster_forces"
+INFO_PATH = DATA_PATH / "info.json"
 CLUSTER_SIZES = (3, 4, 5, 6, 7, 8)
 REFERENCES = (
     ("mad2", "MAD2"),
@@ -54,12 +57,8 @@ class ClusterForcesApp(BaseApp):
             for reference_key, reference_label in REFERENCES:
                 for cluster_size in CLUSTER_SIZES:
                     metric_name = _metric_name(reference_label, cluster_size)
-                    figure_path = (
-                        DATA_PATH
-                        / (
-                            f"figure_force_parity_{reference_key}_"
-                            f"{cluster_size}atoms.json"
-                        )
+                    figure_path = DATA_PATH / (
+                        f"figure_force_parity_{reference_key}_{cluster_size}atoms.json"
                     )
                     if not figure_path.exists():
                         continue
@@ -135,6 +134,7 @@ def get_app() -> ClusterForcesApp:
             Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
             Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
         ],
+        info_path=INFO_PATH,
     )
 
 

--- a/ml_peg/app/clusters/cluster_forces/app_cluster_forces.py
+++ b/ml_peg/app/clusters/cluster_forces/app_cluster_forces.py
@@ -7,20 +7,31 @@ from dash.html import Div
 
 from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
-from ml_peg.app.utils.build_callbacks import plot_from_table_column
-from ml_peg.app.utils.load import read_plot
+from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
+from ml_peg.app.utils.load import read_density_plot_for_model
+from ml_peg.models import current_models
+from ml_peg.models.get_models import get_model_names
+
+MODELS = get_model_names(current_models)
 
 BENCHMARK_NAME = "Cluster Forces"
+DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/clusters.html#cluster-forces"
 DATA_PATH = APP_ROOT / "data" / "clusters" / "cluster_forces"
 CLUSTER_SIZES = (3, 4, 5, 6, 7, 8)
+REFERENCES = (
+    ("mad2", "MAD2"),
+    ("omol25", "OMOL25"),
+)
 
 
-def _metric_name(cluster_size: int) -> str:
+def _metric_name(reference_label: str, cluster_size: int) -> str:
     """
-    Return the metric name for a cluster size.
+    Return the metric name for a reference and cluster size.
 
     Parameters
     ----------
+    reference_label
+        Reference force-set label.
     cluster_size
         Number of atoms in the cluster.
 
@@ -29,26 +40,78 @@ def _metric_name(cluster_size: int) -> str:
     str
         Metric label.
     """
-    return f"Force MAE ({cluster_size} atoms)"
+    return f"{reference_label} Force MAE ({cluster_size} atoms)"
 
 
 class ClusterForcesApp(BaseApp):
     """Cluster-force benchmark app layout and callbacks."""
 
     def register_callbacks(self) -> None:
-        """Register force parity callbacks."""
-        column_to_plot = {
-            _metric_name(cluster_size): read_plot(
-                DATA_PATH / f"figure_force_parity_{cluster_size}mer.json",
-                id=f"{BENCHMARK_NAME}-{cluster_size}mer-force-parity-figure",
-            )
-            for cluster_size in CLUSTER_SIZES
-        }
-        plot_from_table_column(
+        """Register force parity and structure callbacks."""
+        density_plots: dict[str, dict] = {}
+        for model in MODELS:
+            model_plots = {}
+            for reference_key, reference_label in REFERENCES:
+                for cluster_size in CLUSTER_SIZES:
+                    metric_name = _metric_name(reference_label, cluster_size)
+                    figure_path = (
+                        DATA_PATH
+                        / (
+                            f"figure_force_parity_{reference_key}_"
+                            f"{cluster_size}atoms.json"
+                        )
+                    )
+                    if not figure_path.exists():
+                        continue
+                    density_graph = read_density_plot_for_model(
+                        filename=figure_path,
+                        model=model,
+                        id=(
+                            f"{BENCHMARK_NAME}-{model}-{reference_key}-"
+                            f"{cluster_size}atoms-density"
+                        ),
+                    )
+                    if density_graph is not None:
+                        model_plots[metric_name] = density_graph
+            if model_plots:
+                density_plots[model] = model_plots
+
+        plot_from_table_cell(
             table_id=self.table_id,
             plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
-            column_to_plot=column_to_plot,
+            cell_to_plot=density_plots,
         )
+
+        for model in MODELS:
+            for reference_key, _ in REFERENCES:
+                for cluster_size in CLUSTER_SIZES:
+                    traj_dir = (
+                        DATA_PATH
+                        / model
+                        / "density_traj"
+                        / f"{reference_key}_{cluster_size}atoms"
+                    )
+                    if not traj_dir.exists():
+                        continue
+                    traj_files = sorted(
+                        traj_dir.glob("*.extxyz"), key=lambda path: int(path.stem)
+                    )
+                    struct_from_scatter(
+                        scatter_id=(
+                            f"{BENCHMARK_NAME}-{model}-{reference_key}-"
+                            f"{cluster_size}atoms-density"
+                        ),
+                        struct_id=f"{BENCHMARK_NAME}-struct-placeholder",
+                        structs=[
+                            (
+                                f"/assets/clusters/cluster_forces/{model}/"
+                                f"density_traj/{reference_key}_{cluster_size}atoms/"
+                                f"{path.name}"
+                            )
+                            for path in traj_files
+                        ],
+                        mode="traj",
+                    )
 
 
 def get_app() -> ClusterForcesApp:
@@ -63,12 +126,15 @@ def get_app() -> ClusterForcesApp:
     return ClusterForcesApp(
         name=BENCHMARK_NAME,
         description=(
-            "Component-wise force MAE for neutral small clusters, split by cluster "
-            "size. Models are routed to MAD2 or OMOL25 reference forces according "
-            "to their training domain."
+            "Component-wise force MAE for randomly generated neutral 3- to 8-atom "
+            "clusters, split by reference force set and cluster size."
         ),
+        docs_url=DOCS_URL,
         table_path=DATA_PATH / "cluster_forces_metrics_table.json",
-        extra_components=[Div(id=f"{BENCHMARK_NAME}-figure-placeholder")],
+        extra_components=[
+            Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
+            Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
+        ],
     )
 
 

--- a/ml_peg/app/clusters/cluster_forces/app_cluster_forces.py
+++ b/ml_peg/app/clusters/cluster_forces/app_cluster_forces.py
@@ -9,10 +9,6 @@ from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
 from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
 from ml_peg.app.utils.load import read_density_plot_for_model
-from ml_peg.models import current_models
-from ml_peg.models.get_models import get_model_names
-
-MODELS = get_model_names(current_models)
 
 BENCHMARK_NAME = "Cluster Forces"
 DOCS_URL = (
@@ -51,8 +47,9 @@ class ClusterForcesApp(BaseApp):
 
     def register_callbacks(self) -> None:
         """Register force parity and structure callbacks."""
+        models = [row["id"] for row in self.table.data if row.get("id")]
         density_plots: dict[str, dict] = {}
-        for model in MODELS:
+        for model in models:
             model_plots = {}
             for reference_key, reference_label in REFERENCES:
                 for cluster_size in CLUSTER_SIZES:
@@ -81,7 +78,7 @@ class ClusterForcesApp(BaseApp):
             cell_to_plot=density_plots,
         )
 
-        for model in MODELS:
+        for model in models:
             for reference_key, _ in REFERENCES:
                 for cluster_size in CLUSTER_SIZES:
                     traj_dir = (
@@ -126,7 +123,8 @@ def get_app() -> ClusterForcesApp:
         name=BENCHMARK_NAME,
         description=(
             "Component-wise force MAE for randomly generated neutral 3- to 8-atom "
-            "clusters, split by reference force set and cluster size."
+            "clusters, split by reference force set and cluster size. Native and "
+            "dispersion-corrected results are shown where applicable."
         ),
         docs_url=DOCS_URL,
         table_path=DATA_PATH / "cluster_forces_metrics_table.json",

--- a/ml_peg/app/clusters/clusters.yml
+++ b/ml_peg/app/clusters/clusters.yml
@@ -1,0 +1,3 @@
+title: Clusters
+description: Force prediction on small atomistic clusters.
+weight: 1

--- a/ml_peg/app/utils/build_components.py
+++ b/ml_peg/app/utils/build_components.py
@@ -307,6 +307,7 @@ def build_weight_components(
     model_levels = getattr(table, "model_levels_of_theory", None)
     metric_levels = getattr(table, "metric_levels_of_theory", None)
     model_configs = getattr(table, "model_configs", None)
+    model_name_map = getattr(table, "model_name_map", None)
 
     # Callbacks to update table scores when table weight dicts change
     if table.id != "summary-table":
@@ -316,6 +317,7 @@ def build_weight_components(
             model_levels=model_levels,
             metric_levels=metric_levels,
             model_configs=model_configs,
+            model_name_map=model_name_map,
         )
     else:
         register_summary_table_callbacks(

--- a/ml_peg/app/utils/load.py
+++ b/ml_peg/app/utils/load.py
@@ -62,6 +62,7 @@ def rebuild_table(
 
     columns = table_json["columns"]
     model_name_map = dict(table_json.get("model_name_map") or {})
+    summary_model_ids = dict(table_json.get("summary_model_ids") or {})
     thresholds = clean_thresholds(table_json.get("thresholds"))
     if not thresholds:
         raise ValueError(f"No thresholds defined in table JSON: {filename}")
@@ -225,6 +226,7 @@ def rebuild_table(
     table.model_configs = model_configs
     table.tooltip_data = tooltip_rows
     table.model_name_map = model_name_map
+    table.summary_model_ids = summary_model_ids
     table.column_widths = column_widths
 
     return table

--- a/ml_peg/app/utils/register_callbacks.py
+++ b/ml_peg/app/utils/register_callbacks.py
@@ -267,6 +267,7 @@ def register_category_table_callbacks(
     model_levels: dict[str, str | None] | None = None,
     metric_levels: dict[str, str | None] | None = None,
     model_configs: dict[str, Any] | None = None,
+    model_name_map: dict[str, str] | None = None,
 ) -> None:
     """
     Register callback to update table scores when stored values change.
@@ -285,6 +286,8 @@ def register_category_table_callbacks(
         Mapping of metric name -> level of theory metadata.
     model_configs
         Optional configuration metadata for each model.
+    model_name_map
+        Optional mapping of model display names to registered model identifiers.
     """
 
     @callback(
@@ -346,8 +349,12 @@ def register_category_table_callbacks(
             stored_raw_data, stored_computed_data, thresholds, toggle_value
         )
         scored_rows = calc_metric_scores(stored_raw_data, thresholds=thresholds)
-        filtered_rows = filter_rows_by_models(display_rows, selected_models)
-        filtered_scores = filter_rows_by_models(scored_rows, selected_models)
+        filtered_rows = filter_rows_by_models(
+            display_rows, selected_models, model_name_map
+        )
+        filtered_scores = filter_rows_by_models(
+            scored_rows, selected_models, model_name_map
+        )
         style = (
             get_table_style(
                 filtered_rows,
@@ -443,8 +450,12 @@ def register_category_table_callbacks(
                     stored_raw_data, stored_computed_data, thresholds, toggle_value
                 )
                 scored_rows = calc_metric_scores(stored_raw_data, thresholds=thresholds)
-                filtered_rows = filter_rows_by_models(display_rows, selected_models)
-                filtered_scores = filter_rows_by_models(scored_rows, selected_models)
+                filtered_rows = filter_rows_by_models(
+                    display_rows, selected_models, model_name_map
+                )
+                filtered_scores = filter_rows_by_models(
+                    scored_rows, selected_models, model_name_map
+                )
                 style = (
                     get_table_style(
                         filtered_rows,
@@ -487,8 +498,12 @@ def register_category_table_callbacks(
             display_rows = get_scores(
                 metrics_data, scored_rows, thresholds, toggle_value
             )
-            filtered_rows = filter_rows_by_models(display_rows, selected_models)
-            filtered_scores = filter_rows_by_models(scored_rows, selected_models)
+            filtered_rows = filter_rows_by_models(
+                display_rows, selected_models, model_name_map
+            )
+            filtered_scores = filter_rows_by_models(
+                scored_rows, selected_models, model_name_map
+            )
             style = (
                 get_table_style(
                     filtered_rows,
@@ -560,7 +575,9 @@ def register_category_table_callbacks(
                 scored_rows = source_data
                 updated_store = no_update
 
-            filtered_rows = filter_rows_by_models(scored_rows, selected_models)
+            filtered_rows = filter_rows_by_models(
+                scored_rows, selected_models, model_name_map
+            )
             style = (
                 get_table_style(filtered_rows, cmap_name=cmap_name or "viridis_r")
                 if filtered_rows
@@ -627,7 +644,9 @@ def register_category_table_callbacks(
             if not computed_store:
                 raise PreventUpdate
 
-            filtered_rows = filter_rows_by_models(computed_store, selected_models)
+            filtered_rows = filter_rows_by_models(
+                computed_store, selected_models, model_name_map
+            )
             style = (
                 get_table_style(filtered_rows, cmap_name=cmap_name or "viridis_r")
                 if filtered_rows
@@ -712,6 +731,7 @@ def register_benchmark_to_category_callback(
                 "benchmark_table_id": benchmark_table.id,
                 "benchmark_column": test_name + " Score",
                 "model_name_map": getattr(benchmark_table, "model_name_map", {}),
+                "summary_model_ids": getattr(benchmark_table, "summary_model_ids", {}),
             }
 
     outputs = []
@@ -773,11 +793,15 @@ def register_benchmark_to_category_callback(
                 benchmark_rows = next(iterator)
 
                 name_map = table_info["model_name_map"]
+                summary_model_ids = table_info["summary_model_ids"]
                 benchmark_column = table_info["benchmark_column"]
 
                 for row in benchmark_rows:
                     display_name = row.get("MLIP")
                     original_name = name_map.get(display_name, display_name)
+                    preferred_id = summary_model_ids.get(original_name, original_name)
+                    if row.get("id", original_name) != preferred_id:
+                        continue
                     if original_name not in updated_by_mlip:
                         continue
 

--- a/ml_peg/app/utils/utils.py
+++ b/ml_peg/app/utils/utils.py
@@ -403,6 +403,7 @@ def none_to_nan(rows: list[dict]) -> None:
 def filter_rows_by_models(
     rows: list[dict] | None,
     selected_models: Sequence[str] | None,
+    model_name_map: Mapping[str, str] | None = None,
 ) -> list[dict]:
     """
     Filter table rows to only those whose model identifier is selected.
@@ -414,6 +415,9 @@ def filter_rows_by_models(
         canonical model key.
     selected_models
         Model identifiers to keep. ``None`` returns the original rows unchanged.
+    model_name_map
+        Optional mapping of row display names to registered model identifiers. This
+        allows all variants of a selected model to remain visible.
 
     Returns
     -------
@@ -427,10 +431,13 @@ def filter_rows_by_models(
     selected = {m for m in selected_models if m}
     if not selected:
         return []
+    name_map = model_name_map or {}
     return [
         row
         for row in rows
-        if (row.get("MLIP") in selected) or (row.get("id") in selected)
+        if (row.get("MLIP") in selected)
+        or (row.get("id") in selected)
+        or (name_map.get(row.get("MLIP")) in selected)
     ]
 
 

--- a/ml_peg/calcs/clusters/cluster_forces/calc_cluster_forces.py
+++ b/ml_peg/calcs/clusters/cluster_forces/calc_cluster_forces.py
@@ -32,7 +32,14 @@ PRED_FORCES_KEY = "pred_forces"
 
 
 def _cluster_data_path() -> Path:
-    # download and locate the cluster extended XYZ file
+    """
+    Locate the downloaded cluster extended XYZ file.
+
+    Returns
+    -------
+    Path
+        Path to the cluster input file.
+    """
     data_dir = download_s3_data(key=S3_KEY, filename=S3_FILENAME)
     candidates = [
         data_dir / INPUT_FILENAME,
@@ -51,7 +58,19 @@ def _cluster_data_path() -> Path:
 
 
 def _count_extxyz_frames(path: Path) -> int:
-    # counts structures quickly within an extended XYZ file
+    """
+    Count structures in an extended XYZ file.
+
+    Parameters
+    ----------
+    path
+        Extended XYZ file.
+
+    Returns
+    -------
+    int
+        Number of structures in the file.
+    """
     count = 0
     with path.open(encoding="utf8") as file:
         while True:
@@ -84,14 +103,32 @@ def _count_extxyz_frames(path: Path) -> int:
 
 
 def _spin_multiplicity(atoms: Atoms) -> int:
-    # return singlet/doublet spin multiplicity for a neutral cluster:
-    # 1 for an even number of electrons, otherwise 2
+    """
+    Return singlet/doublet spin multiplicity for a neutral cluster.
+
+    Parameters
+    ----------
+    atoms
+        Cluster structure.
+
+    Returns
+    -------
+    int
+        Spin multiplicity.
+    """
     n_electrons = int(np.sum(atoms.get_atomic_numbers()))
     return 1 if n_electrons % 2 == 0 else 2
 
 
 def _set_charge_and_spin(atoms: Atoms) -> None:
-    # sets charge and spin information in-place on an Atoms object
+    """
+    Set charge and spin metadata in-place.
+
+    Parameters
+    ----------
+    atoms
+        Cluster structure to update.
+    """
     spin_multiplicity = _spin_multiplicity(atoms)
     atoms.info["charge"] = 0
     atoms.info["spin"] = spin_multiplicity
@@ -99,7 +136,21 @@ def _set_charge_and_spin(atoms: Atoms) -> None:
 
 
 def _reference_forces(atoms: Atoms, reference_key: str) -> np.ndarray:
-    # gets reference forces from an input cluster
+    """
+    Get reference forces from an input cluster.
+
+    Parameters
+    ----------
+    atoms
+        Cluster structure.
+    reference_key
+        Name of the reference-force array.
+
+    Returns
+    -------
+    np.ndarray
+        Reference forces.
+    """
     if reference_key not in atoms.arrays:
         raise KeyError(f"Missing '{reference_key}' in cluster input.")
     return np.asarray(atoms.arrays[reference_key], dtype=float)

--- a/ml_peg/calcs/clusters/cluster_forces/calc_cluster_forces.py
+++ b/ml_peg/calcs/clusters/cluster_forces/calc_cluster_forces.py
@@ -14,10 +14,9 @@ from tqdm.auto import tqdm
 
 from ml_peg.calcs.utils.utils import download_s3_data
 from ml_peg.models import current_models
-from ml_peg.models.get_models import load_model_configs, load_models
+from ml_peg.models.get_models import load_models
 
 MODELS = load_models(current_models)
-MODEL_CONFIGS, _ = load_model_configs(tuple(MODELS))
 
 OUT_PATH = Path(__file__).parent / "outputs"
 BENCHMARK_FILENAME = "cluster_forces.extxyz"
@@ -27,70 +26,13 @@ INPUT_FILENAME = "clusters.xyz"
 
 MAD2_FORCES_KEY = "mad2_forces"
 OMOL25_FORCES_KEY = "omol25_forces"
-ORGANIC_MODEL_MARKERS = ("omol", "off", "polar")
-
-
-def _is_organic_focused_model(model_name: str, model_config: dict[str, Any]) -> bool:
-    """
-    Return whether a model should be compared to OMOL25 reference forces.
-
-    Parameters
-    ----------
-    model_name
-        Model identifier from ``models.yml``.
-    model_config
-        Model configuration from ``models.yml``.
-
-    Returns
-    -------
-    bool
-        Whether the model is organic-chemistry focused.
-    """
-    kwargs = model_config.get("kwargs") or {}
-    searchable_fields = [
-        model_name,
-        model_config.get("class_name", ""),
-        model_config.get("module", ""),
-        kwargs.get("task_name", ""),
-        kwargs.get("name", ""),
-        kwargs.get("model", ""),
-        kwargs.get("head", ""),
-    ]
-    searchable = " ".join(str(field).lower() for field in searchable_fields)
-    return any(marker in searchable for marker in ORGANIC_MODEL_MARKERS)
-
-
-def _reference_forces_key(model_name: str) -> str:
-    """
-    Select the force reference array for a model.
-
-    Organic-focused models are routed to OMOL25 forces. Models trained on broad
-    atomistic data or primarily on materials are routed to MAD2 forces.
-
-    Parameters
-    ----------
-    model_name
-        Model identifier from ``models.yml``.
-
-    Returns
-    -------
-    str
-        Extended XYZ array key containing the appropriate reference forces.
-    """
-    if _is_organic_focused_model(model_name, MODEL_CONFIGS.get(model_name, {})):
-        return OMOL25_FORCES_KEY
-    return MAD2_FORCES_KEY
+MAD2_REF_FORCES_KEY = "mad2_ref_forces"
+OMOL25_REF_FORCES_KEY = "omol25_ref_forces"
+PRED_FORCES_KEY = "pred_forces"
 
 
 def _cluster_data_path() -> Path:
-    """
-    Download and locate the cluster extended XYZ file.
-
-    Returns
-    -------
-    pathlib.Path
-        Path to ``clusters.xyz``.
-    """
+    # download and locate the cluster extended XYZ file
     data_dir = download_s3_data(key=S3_KEY, filename=S3_FILENAME)
     candidates = [
         data_dir / INPUT_FILENAME,
@@ -108,69 +50,66 @@ def _cluster_data_path() -> Path:
     )
 
 
+def _count_extxyz_frames(path: Path) -> int:
+    # counts structures quickly within an extended XYZ file
+    count = 0
+    with path.open(encoding="utf8") as file:
+        while True:
+            line = file.readline()
+            if not line:
+                break
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                n_atoms = int(stripped)
+            except ValueError as err:
+                raise ValueError(
+                    f"Expected atom-count line while reading {path}: {stripped!r}"
+                ) from err
+            comment = file.readline()
+            if not comment:
+                raise ValueError(
+                    f"Unexpected end of file after frame {count} in {path}"
+                )
+            for _ in range(n_atoms):
+                atom_line = file.readline()
+                if not atom_line:
+                    raise ValueError(
+                        f"Unexpected end of file in atom block for frame {count} "
+                        f"in {path}"
+                    )
+            count += 1
+    return count
+
+
 def _spin_multiplicity(atoms: Atoms) -> int:
-    """
-    Return singlet/doublet spin multiplicity for a neutral cluster.
-
-    Parameters
-    ----------
-    atoms
-        Cluster to inspect.
-
-    Returns
-    -------
-    int
-        ``1`` for an even number of electrons, otherwise ``2``.
-    """
+    # return singlet/doublet spin multiplicity for a neutral cluster:
+    # 1 for an even number of electrons, otherwise 2
     n_electrons = int(np.sum(atoms.get_atomic_numbers()))
     return 1 if n_electrons % 2 == 0 else 2
 
 
 def _set_charge_and_spin(atoms: Atoms) -> None:
-    """
-    Set neutral charge and parity-based spin metadata in-place.
-
-    Parameters
-    ----------
-    atoms
-        Cluster whose metadata should be updated.
-    """
+    # sets charge and spin information in-place on an Atoms object
     spin_multiplicity = _spin_multiplicity(atoms)
     atoms.info["charge"] = 0
     atoms.info["spin"] = spin_multiplicity
     atoms.info["spin_multiplicity"] = spin_multiplicity
 
 
-def _finite_reference_forces(atoms: Atoms, reference_key: str) -> np.ndarray | None:
-    """
-    Get finite reference forces from an input cluster.
-
-    Parameters
-    ----------
-    atoms
-        Cluster read from ``clusters.xyz``.
-    reference_key
-        Extended XYZ array key to load.
-
-    Returns
-    -------
-    numpy.ndarray | None
-        Reference forces, or ``None`` when the selected reference is non-finite.
-    """
+def _reference_forces(atoms: Atoms, reference_key: str) -> np.ndarray:
+    # gets reference forces from an input cluster
     if reference_key not in atoms.arrays:
         raise KeyError(f"Missing '{reference_key}' in cluster input.")
-
-    ref_forces = np.asarray(atoms.arrays[reference_key], dtype=float)
-    if not np.isfinite(ref_forces).all():
-        return None
-    return ref_forces
+    return np.asarray(atoms.arrays[reference_key], dtype=float)
 
 
-@pytest.mark.very_slow
+@pytest.mark.slow
 @pytest.mark.parametrize("mlip", MODELS.items())
 def test_cluster_forces(mlip: tuple[str, Any]) -> None:
     """
-    Compare MLIP forces to the routed MAD2 or OMOL25 cluster-force reference.
+    Evaluate MLIP forces for comparison to MAD2 and OMOL25 references.
 
     Parameters
     ----------
@@ -178,50 +117,62 @@ def test_cluster_forces(mlip: tuple[str, Any]) -> None:
         Tuple of ``(model_name, model)`` as provided by ``MODELS.items()``.
     """
     model_name, model = mlip
-    reference_key = _reference_forces_key(model_name)
-    reference_target = "OMOL25" if reference_key == OMOL25_FORCES_KEY else "MAD2"
 
     calc = model.get_calculator(precision="high")
     data_path = _cluster_data_path()
     out_dir = OUT_PATH / model_name
     out_dir.mkdir(parents=True, exist_ok=True)
 
+    n_clusters = _count_extxyz_frames(data_path)
     frames = iread(data_path, index=":")
     if sys.stderr.isatty():
-        frames = tqdm(frames, desc=f"{model_name} cluster forces", unit="cluster")
+        frames = tqdm(
+            frames,
+            desc=f"{model_name} cluster forces",
+            total=n_clusters,
+            unit="cluster",
+        )
 
     results: list[Atoms] = []
-    skipped_non_finite = 0
+    failed_calculations = 0
     for structure_index, atoms in enumerate(frames):
-        ref_forces = _finite_reference_forces(atoms, reference_key)
-        if ref_forces is None:
-            skipped_non_finite += 1
-            continue
-
         atoms_pred = atoms.copy()
         _set_charge_and_spin(atoms_pred)
         atoms_pred.calc = calc
 
+        try:
+            pred_forces = np.asarray(atoms_pred.get_forces(), dtype=float)
+            calculation_failed = False
+            calculation_error = ""
+        except Exception as err:
+            pred_forces = np.full((len(atoms_pred), 3), np.nan, dtype=float)
+            calculation_failed = True
+            calculation_error = f"{type(err).__name__}: {err}"
+            failed_calculations += 1
+
         out_atoms = atoms.copy()
         _set_charge_and_spin(out_atoms)
+        out_atoms.info["structure_index"] = structure_index
+        out_atoms.info["calculation_failed"] = calculation_failed
+        if calculation_error:
+            out_atoms.info["calculation_error"] = calculation_error[:500]
+
+        out_atoms.arrays[MAD2_REF_FORCES_KEY] = _reference_forces(
+            out_atoms, MAD2_FORCES_KEY
+        )
+        out_atoms.arrays[OMOL25_REF_FORCES_KEY] = _reference_forces(
+            out_atoms, OMOL25_FORCES_KEY
+        )
+        out_atoms.arrays[PRED_FORCES_KEY] = pred_forces
         out_atoms.arrays.pop(MAD2_FORCES_KEY, None)
         out_atoms.arrays.pop(OMOL25_FORCES_KEY, None)
-        out_atoms.info["structure_index"] = structure_index
-        out_atoms.info["reference_forces_key"] = reference_key
-        out_atoms.info["reference_target"] = reference_target
-        out_atoms.arrays["ref_forces"] = ref_forces
-        out_atoms.arrays["pred_forces"] = np.asarray(
-            atoms_pred.get_forces(), dtype=float
-        )
         results.append(out_atoms)
 
     if not results:
-        raise ValueError(
-            f"No finite {reference_target} force references found in {data_path}."
-        )
+        raise ValueError(f"No clusters found in {data_path}.")
 
     write(out_dir / BENCHMARK_FILENAME, results)
     print(
-        f"{model_name}: wrote {len(results)} clusters using {reference_target} "
-        f"references; skipped {skipped_non_finite} non-finite references."
+        f"{model_name}: wrote {len(results)} clusters; "
+        f"{failed_calculations} force evaluations failed and were stored as NaNs."
     )

--- a/ml_peg/calcs/clusters/cluster_forces/calc_cluster_forces.py
+++ b/ml_peg/calcs/clusters/cluster_forces/calc_cluster_forces.py
@@ -1,0 +1,227 @@
+"""Evaluate MLIPs on small atomistic clusters using reference forces."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+from ase.atoms import Atoms
+from ase.io import iread, write
+import numpy as np
+import pytest
+from tqdm.auto import tqdm
+
+from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_model_configs, load_models
+
+MODELS = load_models(current_models)
+MODEL_CONFIGS, _ = load_model_configs(tuple(MODELS))
+
+OUT_PATH = Path(__file__).parent / "outputs"
+BENCHMARK_FILENAME = "cluster_forces.extxyz"
+S3_KEY = "inputs/clusters/cluster_forces/cluster_forces.zip"
+S3_FILENAME = "cluster_forces.zip"
+INPUT_FILENAME = "clusters.xyz"
+
+MAD2_FORCES_KEY = "mad2_forces"
+OMOL25_FORCES_KEY = "omol25_forces"
+ORGANIC_MODEL_MARKERS = ("omol", "off", "polar")
+
+
+def _is_organic_focused_model(model_name: str, model_config: dict[str, Any]) -> bool:
+    """
+    Return whether a model should be compared to OMOL25 reference forces.
+
+    Parameters
+    ----------
+    model_name
+        Model identifier from ``models.yml``.
+    model_config
+        Model configuration from ``models.yml``.
+
+    Returns
+    -------
+    bool
+        Whether the model is organic-chemistry focused.
+    """
+    kwargs = model_config.get("kwargs") or {}
+    searchable_fields = [
+        model_name,
+        model_config.get("class_name", ""),
+        model_config.get("module", ""),
+        kwargs.get("task_name", ""),
+        kwargs.get("name", ""),
+        kwargs.get("model", ""),
+        kwargs.get("head", ""),
+    ]
+    searchable = " ".join(str(field).lower() for field in searchable_fields)
+    return any(marker in searchable for marker in ORGANIC_MODEL_MARKERS)
+
+
+def _reference_forces_key(model_name: str) -> str:
+    """
+    Select the force reference array for a model.
+
+    Organic-focused models are routed to OMOL25 forces. Models trained on broad
+    atomistic data or primarily on materials are routed to MAD2 forces.
+
+    Parameters
+    ----------
+    model_name
+        Model identifier from ``models.yml``.
+
+    Returns
+    -------
+    str
+        Extended XYZ array key containing the appropriate reference forces.
+    """
+    if _is_organic_focused_model(model_name, MODEL_CONFIGS.get(model_name, {})):
+        return OMOL25_FORCES_KEY
+    return MAD2_FORCES_KEY
+
+
+def _cluster_data_path() -> Path:
+    """
+    Download and locate the cluster extended XYZ file.
+
+    Returns
+    -------
+    pathlib.Path
+        Path to ``clusters.xyz``.
+    """
+    data_dir = download_s3_data(key=S3_KEY, filename=S3_FILENAME)
+    candidates = [
+        data_dir / INPUT_FILENAME,
+        data_dir / "cluster_forces" / INPUT_FILENAME,
+    ]
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    searched = "\n".join(f"- {candidate}" for candidate in candidates)
+    raise FileNotFoundError(
+        f"Could not find {INPUT_FILENAME} after downloading {S3_KEY}. "
+        f"Searched:\n{searched}"
+    )
+
+
+def _spin_multiplicity(atoms: Atoms) -> int:
+    """
+    Return singlet/doublet spin multiplicity for a neutral cluster.
+
+    Parameters
+    ----------
+    atoms
+        Cluster to inspect.
+
+    Returns
+    -------
+    int
+        ``1`` for an even number of electrons, otherwise ``2``.
+    """
+    n_electrons = int(np.sum(atoms.get_atomic_numbers()))
+    return 1 if n_electrons % 2 == 0 else 2
+
+
+def _set_charge_and_spin(atoms: Atoms) -> None:
+    """
+    Set neutral charge and parity-based spin metadata in-place.
+
+    Parameters
+    ----------
+    atoms
+        Cluster whose metadata should be updated.
+    """
+    spin_multiplicity = _spin_multiplicity(atoms)
+    atoms.info["charge"] = 0
+    atoms.info["spin"] = spin_multiplicity
+    atoms.info["spin_multiplicity"] = spin_multiplicity
+
+
+def _finite_reference_forces(atoms: Atoms, reference_key: str) -> np.ndarray | None:
+    """
+    Get finite reference forces from an input cluster.
+
+    Parameters
+    ----------
+    atoms
+        Cluster read from ``clusters.xyz``.
+    reference_key
+        Extended XYZ array key to load.
+
+    Returns
+    -------
+    numpy.ndarray | None
+        Reference forces, or ``None`` when the selected reference is non-finite.
+    """
+    if reference_key not in atoms.arrays:
+        raise KeyError(f"Missing '{reference_key}' in cluster input.")
+
+    ref_forces = np.asarray(atoms.arrays[reference_key], dtype=float)
+    if not np.isfinite(ref_forces).all():
+        return None
+    return ref_forces
+
+
+@pytest.mark.very_slow
+@pytest.mark.parametrize("mlip", MODELS.items())
+def test_cluster_forces(mlip: tuple[str, Any]) -> None:
+    """
+    Compare MLIP forces to the routed MAD2 or OMOL25 cluster-force reference.
+
+    Parameters
+    ----------
+    mlip
+        Tuple of ``(model_name, model)`` as provided by ``MODELS.items()``.
+    """
+    model_name, model = mlip
+    reference_key = _reference_forces_key(model_name)
+    reference_target = "OMOL25" if reference_key == OMOL25_FORCES_KEY else "MAD2"
+
+    calc = model.get_calculator(precision="high")
+    data_path = _cluster_data_path()
+    out_dir = OUT_PATH / model_name
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    frames = iread(data_path, index=":")
+    if sys.stderr.isatty():
+        frames = tqdm(frames, desc=f"{model_name} cluster forces", unit="cluster")
+
+    results: list[Atoms] = []
+    skipped_non_finite = 0
+    for structure_index, atoms in enumerate(frames):
+        ref_forces = _finite_reference_forces(atoms, reference_key)
+        if ref_forces is None:
+            skipped_non_finite += 1
+            continue
+
+        atoms_pred = atoms.copy()
+        _set_charge_and_spin(atoms_pred)
+        atoms_pred.calc = calc
+
+        out_atoms = atoms.copy()
+        _set_charge_and_spin(out_atoms)
+        out_atoms.arrays.pop(MAD2_FORCES_KEY, None)
+        out_atoms.arrays.pop(OMOL25_FORCES_KEY, None)
+        out_atoms.info["structure_index"] = structure_index
+        out_atoms.info["reference_forces_key"] = reference_key
+        out_atoms.info["reference_target"] = reference_target
+        out_atoms.arrays["ref_forces"] = ref_forces
+        out_atoms.arrays["pred_forces"] = np.asarray(
+            atoms_pred.get_forces(), dtype=float
+        )
+        results.append(out_atoms)
+
+    if not results:
+        raise ValueError(
+            f"No finite {reference_target} force references found in {data_path}."
+        )
+
+    write(out_dir / BENCHMARK_FILENAME, results)
+    print(
+        f"{model_name}: wrote {len(results)} clusters using {reference_target} "
+        f"references; skipped {skipped_non_finite} non-finite references."
+    )

--- a/ml_peg/calcs/clusters/cluster_forces/calc_cluster_forces.py
+++ b/ml_peg/calcs/clusters/cluster_forces/calc_cluster_forces.py
@@ -29,6 +29,7 @@ OMOL25_FORCES_KEY = "omol25_forces"
 MAD2_REF_FORCES_KEY = "mad2_ref_forces"
 OMOL25_REF_FORCES_KEY = "omol25_ref_forces"
 PRED_FORCES_KEY = "pred_forces"
+DISPERSION_PRED_FORCES_KEY = "dispersion_pred_forces"
 
 
 def _cluster_data_path() -> Path:
@@ -170,6 +171,9 @@ def test_cluster_forces(mlip: tuple[str, Any]) -> None:
     model_name, model = mlip
 
     calc = model.get_calculator(precision="high")
+    dispersion_calc = None
+    if not model.trained_on_dispersion:
+        dispersion_calc = model.add_d3_calculator(calc)
     data_path = _cluster_data_path()
     out_dir = OUT_PATH / model_name
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -186,27 +190,48 @@ def test_cluster_forces(mlip: tuple[str, Any]) -> None:
 
     results: list[Atoms] = []
     failed_calculations = 0
+    failed_dispersion_calculations = 0
     for structure_index, atoms in enumerate(frames):
         atoms_pred = atoms.copy()
         _set_charge_and_spin(atoms_pred)
         atoms_pred.calc = calc
-
         try:
             pred_forces = np.asarray(atoms_pred.get_forces(), dtype=float)
-            calculation_failed = False
             calculation_error = ""
         except Exception as err:
             pred_forces = np.full((len(atoms_pred), 3), np.nan, dtype=float)
-            calculation_failed = True
             calculation_error = f"{type(err).__name__}: {err}"
             failed_calculations += 1
+
+        dispersion_pred_forces = None
+        dispersion_calculation_error = ""
+        if dispersion_calc is not None:
+            atoms_pred.calc = dispersion_calc
+            try:
+                dispersion_pred_forces = np.asarray(
+                    atoms_pred.get_forces(), dtype=float
+                )
+            except Exception as err:
+                dispersion_pred_forces = np.full(
+                    (len(atoms_pred), 3), np.nan, dtype=float
+                )
+                dispersion_calculation_error = f"{type(err).__name__}: {err}"
+                failed_dispersion_calculations += 1
 
         out_atoms = atoms.copy()
         _set_charge_and_spin(out_atoms)
         out_atoms.info["structure_index"] = structure_index
-        out_atoms.info["calculation_failed"] = calculation_failed
+        out_atoms.info["calculation_failed"] = bool(calculation_error)
         if calculation_error:
             out_atoms.info["calculation_error"] = calculation_error[:500]
+        if dispersion_calc is not None:
+            out_atoms.info["dispersion_calculation_failed"] = bool(
+                dispersion_calculation_error
+            )
+            if dispersion_calculation_error:
+                out_atoms.info["dispersion_calculation_error"] = (
+                    dispersion_calculation_error[:500]
+                )
 
         out_atoms.arrays[MAD2_REF_FORCES_KEY] = _reference_forces(
             out_atoms, MAD2_FORCES_KEY
@@ -215,6 +240,8 @@ def test_cluster_forces(mlip: tuple[str, Any]) -> None:
             out_atoms, OMOL25_FORCES_KEY
         )
         out_atoms.arrays[PRED_FORCES_KEY] = pred_forces
+        if dispersion_pred_forces is not None:
+            out_atoms.arrays[DISPERSION_PRED_FORCES_KEY] = dispersion_pred_forces
         out_atoms.arrays.pop(MAD2_FORCES_KEY, None)
         out_atoms.arrays.pop(OMOL25_FORCES_KEY, None)
         results.append(out_atoms)
@@ -225,5 +252,12 @@ def test_cluster_forces(mlip: tuple[str, Any]) -> None:
     write(out_dir / BENCHMARK_FILENAME, results)
     print(
         f"{model_name}: wrote {len(results)} clusters; "
-        f"{failed_calculations} force evaluations failed and were stored as NaNs."
+        f"{failed_calculations} native force evaluations failed"
+        + (
+            f"; {failed_dispersion_calculations} dispersion-corrected force "
+            "evaluations failed"
+            if dispersion_calc is not None
+            else ""
+        )
+        + ". Failed evaluations were stored as NaNs."
     )

--- a/tests/test_model_variants.py
+++ b/tests/test_model_variants.py
@@ -1,0 +1,82 @@
+"""Test model variants in benchmark tables."""
+
+from __future__ import annotations
+
+import json
+
+from dash.dash_table import DataTable
+
+from ml_peg.analysis.utils.decorators import build_table
+from ml_peg.app.build_app import build_summary_table
+from ml_peg.app.utils.utils import filter_rows_by_models
+from ml_peg.models.get_models import get_model_names
+
+
+def test_build_table_model_variants(tmp_path):
+    """Keep model variants distinct while associating them with one base model."""
+    base_model = get_model_names()[0]
+    corrected_model = f"{base_model}-test-D3"
+    table_path = tmp_path / "table.json"
+
+    @build_table(
+        filename=table_path,
+        thresholds={
+            "Force MAE": {
+                "good": 0.0,
+                "bad": 1.0,
+                "unit": "eV/A",
+            }
+        },
+        model_variants={corrected_model: base_model},
+        summary_model_ids={base_model: corrected_model},
+    )
+    def make_table():
+        return {
+            "Force MAE": {
+                base_model: 0.2,
+                corrected_model: 0.1,
+            }
+        }
+
+    make_table()
+
+    with table_path.open(encoding="utf8") as file:
+        table = json.load(file)
+
+    rows = {row["id"]: row for row in table["data"]}
+    assert rows[base_model]["Force MAE"] == 0.2
+    assert rows[corrected_model]["Force MAE"] == 0.1
+    assert table["model_name_map"][corrected_model] == base_model
+    assert table["summary_model_ids"][base_model] == corrected_model
+
+    filtered_rows = filter_rows_by_models(
+        table["data"], [base_model], table["model_name_map"]
+    )
+    assert {row["id"] for row in filtered_rows} == {base_model, corrected_model}
+
+
+def test_summary_table_uses_preferred_variant():
+    """Use the configured corrected variant for aggregate benchmark scores."""
+    base_model = get_model_names()[0]
+    corrected_model = f"{base_model}-test-D3"
+    benchmark_table = DataTable(
+        data=[
+            {"MLIP": base_model, "id": base_model, "Score": 0.2},
+            {"MLIP": corrected_model, "id": corrected_model, "Score": 0.8},
+        ],
+        columns=[
+            {"name": "MLIP", "id": "MLIP"},
+            {"name": "Score", "id": "Score"},
+        ],
+    )
+    benchmark_table.description = "Test benchmark"
+    benchmark_table.model_name_map = {
+        base_model: base_model,
+        corrected_model: base_model,
+    }
+    benchmark_table.summary_model_ids = {base_model: corrected_model}
+
+    summary = build_summary_table({"Cluster Forces": benchmark_table})
+    model_row = next(row for row in summary.data if row["MLIP"] == base_model)
+
+    assert model_row["Cluster Forces Score"] == 0.8


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to a "new benchmark" issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

As described in #546, this benchmark evaluates force accuracies on small atomic clusters.

## Linked issue

<!-- Enter the number of the issue this resolves. This should be labelled as "new benchmark". -->
Resolves #546

## Progress

<!-- Which aspects of adding the new benchmark are complete? Any issues encountered can also be discussed here. -->
- [x] Calculations
- [x] Analysis
- [x] Application
- [x] Documentation

Potential aspects of the benchmark to be discussed with the maintainers:
- weighting of clusters of different sizes (defaults to one for all sizes at the moment)
- energies are excluded for the moment because models can have arbitrary baselines; however, we could run a few DFT calculations to determine isolated atom energies and subtract those from the cluster energies
- the benchmark is marked as "very slow" for the moment because it consists of the evaluation of 60k structures. This is to be tested though, as all structures are very small. It would also be possible to select a smaller subset.
- the benchmark contains random elements up to (and including) the third row of the periodic table. This includes the presence of clusters including noble gases, which are often not well-represented in training sets. Also depending on the performance of the existing models on those, we might want to decide to exclude cluster containing noble gases

## Testing

<!-- Which models have you tested your benchmark on? -->
We carefully checked consistency of the labels with the publicly available OMol25 and MAD-1.5 datasets. The benchmark has not been tested on any models yet.

## New decorators/callbacks

<!-- Are new callbacks required for the interactivity you need? -->
No new callbacks are needed.
