### PR TITLE
⚡ Bolt: Replace iterrows with itertuples for faster DataFrame iteration

### DIFF
--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -238,7 +238,7 @@ def run_elasticity_benchmark(
 
     # Save relaxed structures to extxyz for visualisation
     atoms_list = []
-    for _, row in results.iterrows():
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if struct is not None:
             atoms = AseAtomsAdaptor.get_atoms(struct).copy()

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,9 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,9 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,11 +106,11 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        for row in tqdm(df_refs.itertuples(), dataset, total=df_refs.shape[0]):
             atoms_list = []
-            identifier = row["Reaction"]
-            reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.
-            e_rel_ref = row["Reference"]
+            identifier = row.Reaction
+            reactions = row.Stoichiometry.split(",")  # Parse stoichiometry string.
+            e_rel_ref = row.Reference
             num_species = len(reactions) // 2  # Each species has coefficient and name.
 
             e_rel_model = 0


### PR DESCRIPTION
💡 What:
Replaced `iterrows()` with `itertuples()` and `to_dict('records')` in Pandas DataFrame iterations across multiple calculation scripts (`calc_elasticity.py`, `gscdb138.py`, `calc_MPCONF196.py`, `calc_solvMPCONF196.py`).

🎯 Why:
Pandas `iterrows()` is a known performance bottleneck in Python data processing because it wraps each row in a `pd.Series`, generating massive overhead in loops. By switching to `itertuples()` (which returns named tuples or standard tuples) and `to_dict('records')` (which returns native Python dictionaries), we bypass the Series overhead completely without sacrificing readability.

📊 Impact:
Iterating over rows becomes significantly faster (often 10x-50x quicker depending on dataframe size and contents). This directly accelerates the setup and processing stages in benchmark tests and analyses.

🔬 Measurement:
To verify, one can run benchmarking scripts using `timeit` comparing `df.iterrows()` vs `df.itertuples()` vs `df.to_dict('records')` on sample dataframes. Also, existing calculations like MPCONF196 will noticeably complete their setup/iteration loops in less time.

---
*PR created automatically by Jules for task [14578147934914453641](https://jules.google.com/task/14578147934914453641) started by @alinelena*