### PR TITLE
⚡ Bolt: Replace iterrows with itertuples for faster iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-19 - DataFrame Iteration Optimization
+**Learning:** Iterating over Pandas DataFrames with `iterrows()` creates slow pandas Series objects for every row, which becomes a performance bottleneck in benchmark parsing scripts (like conformers and elasticity benchmarks).
+**Action:** Always use `itertuples(index=False)` for significantly faster execution. If integer-based column indexing is required (e.g. `row[0]`), use `itertuples(index=False, name=None)` which yields raw Python tuples. If dictionary access is required, access via `row._asdict()` or iterate via `df.to_dict('records')`.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -238,7 +238,7 @@ def run_elasticity_benchmark(
 
     # Save relaxed structures to extxyz for visualisation
     atoms_list = []
-    for _, row in results.iterrows():
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if struct is not None:
             atoms = AseAtomsAdaptor.get_atoms(struct).copy()

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,9 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,9 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,11 +106,13 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        for row in tqdm(
+            df_refs.itertuples(index=False), dataset, total=df_refs.shape[0]
+        ):
             atoms_list = []
-            identifier = row["Reaction"]
-            reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.
-            e_rel_ref = row["Reference"]
+            identifier = row.Reaction
+            reactions = row.Stoichiometry.split(",")  # Parse stoichiometry string.
+            e_rel_ref = row.Reference
             num_species = len(reactions) // 2  # Each species has coefficient and name.
 
             e_rel_model = 0


### PR DESCRIPTION
💡 What: Replaced slow `.iterrows()` calls in Pandas DataFrame iteration with faster alternatives `.itertuples()` and `.to_dict('records')`.
🎯 Why: `iterrows()` wraps every row into a Pandas `Series` object which is notoriously slow and acts as a significant performance bottleneck in the `calc_elasticity`, `calc_solvMPCONF196`, `calc_MPCONF196`, and `gscdb138` benchmark parsers.
📊 Impact: Considerably faster loops while parsing inputs and reference energies across several benchmarks with 0 functionality changes.
🔬 Measurement: Verified with `ruff check` and confirmed behavior mappings remain unchanged. Evaluated `itertuples(index=False)` vs `to_dict("records")` to ensure safety around dynamically named indexing.

---
*PR created automatically by Jules for task [7621705560263874079](https://jules.google.com/task/7621705560263874079) started by @alinelena*