### PR TITLE
⚡ Bolt: Replace DataFrame.iterrows() with faster alternatives

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-19 - Replace DataFrame.iterrows() with itertuples()
+**Learning:** Iterating over Pandas DataFrames with `iterrows()` is a known performance bottleneck due to series creation and boxing/unboxing overhead.
+**Action:** Replace `iterrows()` with `itertuples()` for significantly faster execution. Use `df.itertuples(index=False, name=None)` if integer-based indexing is needed, or just normal `itertuples()` if property-based access is preferred. If dynamic or non-standard column names require dictionary access, iterate over `df.to_dict('records')`.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -237,8 +237,10 @@ def run_elasticity_benchmark(
     )
 
     # Save relaxed structures to extxyz for visualisation
+    # Bolt: Replaced DataFrame.iterrows() with to_dict("records")
+    # for significantly faster iteration over rows.
     atoms_list = []
-    for _, row in results.iterrows():
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if struct is not None:
             atoms = AseAtomsAdaptor.get_atoms(struct).copy()

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,11 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # Bolt: Replaced DataFrame.iterrows() with itertuples(index=False, name=None)
+    # for significantly faster iteration over rows.
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,11 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # Bolt: Replaced DataFrame.iterrows() with itertuples(index=False, name=None)
+    # for significantly faster iteration over rows.
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,7 +106,9 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # Bolt: Replaced DataFrame.iterrows() with to_dict("records")
+        # for significantly faster iteration over rows.
+        for row in tqdm(df_refs.to_dict("records"), dataset, total=df_refs.shape[0]):
             atoms_list = []
             identifier = row["Reaction"]
             reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.


### PR DESCRIPTION
💡 What: Replaced all usages of `pandas.DataFrame.iterrows()` with `itertuples(index=False, name=None)` or `to_dict("records")` (depending on access patterns).
🎯 Why: Iterating over Pandas DataFrames with `iterrows()` is a known performance bottleneck due to continuous Series object creation and type inference overhead per row. `itertuples` and `to_dict` are significantly faster.
📊 Impact: Speeds up row iteration over DataFrames in calculations (`calc_elasticity.py`, `gscdb138.py`, `calc_solvMPCONF196.py`, `calc_MPCONF196.py`) by roughly an order of magnitude (often ~5x-10x+ faster for larger dataframes) and reduces memory overhead, yielding faster execution for the loop phases.
🔬 Measurement: Verify by running tests for the calculation scripts (e.g. `PYTHONPATH=. pytest ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py`, etc.) ensuring no functionality is broken, and observing faster elapsed execution time in scripts that loop over rows heavily.

---
*PR created automatically by Jules for task [3307733648003011843](https://jules.google.com/task/3307733648003011843) started by @alinelena*