### PR TITLE
⚡ Bolt: Replace iterrows with itertuples/to_dict for faster DataFrame iteration

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-20 - Replace Pandas iterrows() with itertuples() or to_dict('records')
+**Learning:** Iterating over Pandas DataFrames with `iterrows()` is a known performance bottleneck due to series object creation overhead.
+**Action:** Replace `iterrows()` with `itertuples(index=False, name=None)` for significantly faster execution when integer-based indexing is needed, or use `to_dict('records')` if dictionary string-based access is required, especially with dynamic or non-standard column names.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -289,7 +289,7 @@ def run_elasticity_benchmark(
 
     # Save relaxed structures to extxyz for visualisation
     atoms_list = []
-    for _, row in results.iterrows():
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             continue

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,9 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,9 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,7 +106,7 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        for row in tqdm(df_refs.to_dict("records"), dataset, total=df_refs.shape[0]):
             atoms_list = []
             identifier = row["Reaction"]
             reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.


### PR DESCRIPTION
💡 What:
Replaced `iterrows()` with `itertuples(index=False, name=None)` or `to_dict('records')` across several pandas DataFrame iteration loops in the calculation scripts.

🎯 Why:
Iterating over a DataFrame using `iterrows()` is notoriously slow due to the overhead of creating a pandas Series for each row. By using `itertuples` (which yields named/standard tuples) or `to_dict('records')` (which yields dictionaries), the iteration speed is drastically improved because it bypasses the heavy Series construction.

📊 Impact:
Significantly reduces the overhead of inner loops processing large datasets (like reference energies and reactions), yielding a faster overall benchmark execution.

🔬 Measurement:
Run the calculations (e.g. `MPCONF196`, `solvMPCONF196`, `elasticity`) and observe improved processing times for the DataFrame iteration blocks. The changes can be validated by running the mock validation tests provided in the plan execution.

---
*PR created automatically by Jules for task [4555546651179645381](https://jules.google.com/task/4555546651179645381) started by @alinelena*