### PR TITLE
⚡ Bolt: [Replace iterrows() with itertuples() for faster DataFrame iteration]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-19 - DataFrame Iteration Optimization
+**Learning:** Pandas `iterrows()` introduces significant overhead when iterating over DataFrames, acting as a performance bottleneck within data parsing and calculation scripts.
+**Action:** Replace `iterrows()` with `itertuples(index=False)` or `to_dict('records')` depending on how keys/properties need to be accessed to yield significantly faster and memory-efficient iterations without losing desired column resolution.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -291,7 +291,7 @@ def run_elasticity_benchmark(
     atoms_list = []
     # Bolt: Iterate over records dictionary instead of iterrows()
     # for faster iteration while preserving dict access.
-    for row in results.to_dict('records'):
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             continue

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -289,7 +289,9 @@ def run_elasticity_benchmark(
 
     # Save relaxed structures to extxyz for visualisation
     atoms_list = []
-    for _, row in results.iterrows():
+    # Bolt: Iterate over records dictionary instead of iterrows()
+    # for faster iteration while preserving dict access.
+    for row in results.to_dict('records'):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             continue

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # Bolt: Use itertuples() instead of iterrows() for faster iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # Bolt: Use itertuples() instead of iterrows() for faster iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,11 +106,14 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # Bolt: Use itertuples() instead of iterrows() for faster iteration
+        for row in tqdm(
+            df_refs.itertuples(index=False), dataset, total=df_refs.shape[0]
+        ):
             atoms_list = []
-            identifier = row["Reaction"]
-            reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.
-            e_rel_ref = row["Reference"]
+            identifier = row.Reaction
+            reactions = row.Stoichiometry.split(",")  # Parse stoichiometry string.
+            e_rel_ref = row.Reference
             num_species = len(reactions) // 2  # Each species has coefficient and name.
 
             e_rel_model = 0


### PR DESCRIPTION
💡 What: Replaced slow `iterrows()` calls with `itertuples()` and `to_dict('records')` in several benchmark calculation scripts (MPCONF196, solvMPCONF196, elasticity, gscdb138).

🎯 Why: `iterrows()` is notoriously slow in Pandas, acting as a measurable iteration bottleneck. Bypassing it avoids creating Series objects for every row, offering a more memory-efficient and significantly faster loop execution.

📊 Impact: Execution times for iterating over benchmark input structures are substantially reduced without altering the data being extracted or formatted, providing faster test/benchmark setup logic.

🔬 Measurement: Review changes to confirm correct translation of index accessing, `python test_mock_df.py` was used internally to directly compare logic against native `iterrows()`, and all associated linters pass.

---
*PR created automatically by Jules for task [1058709245272794228](https://jules.google.com/task/1058709245272794228) started by @alinelena*