### PR TITLE
⚡ Bolt: [performance improvement] Replace DataFrame.iterrows() with faster alternatives

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-19 - DataFrame Iteration Bottleneck
+**Learning:** Using `iterrows()` on Pandas DataFrames is a known performance bottleneck, particularly when parsing configuration files or large datasets where rows are accessed sequentially in a loop.
+**Action:** Replace `iterrows()` with `itertuples()` for faster performance. Use `itertuples(index=False)` if named access is preferred, `itertuples(index=False, name=None)` for standard tuple access via index. If columns contain non-standard identifiers, iterate using `to_dict('records')`.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -290,7 +290,7 @@ def run_elasticity_benchmark(
     # Save relaxed structures to extxyz for visualisation
     atoms_list = []
     # ⚡ Bolt: Use to_dict('records') instead of iterrows() for faster iteration
-    for row in results.to_dict('records'):
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             continue

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -289,7 +289,8 @@ def run_elasticity_benchmark(
 
     # Save relaxed structures to extxyz for visualisation
     atoms_list = []
-    for _, row in results.iterrows():
+    # ⚡ Bolt: Use to_dict('records') instead of iterrows() for faster iteration
+    for row in results.to_dict('records'):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             continue

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # ⚡ Bolt: Use itertuples() instead of iterrows() for faster iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # ⚡ Bolt: Use itertuples() instead of iterrows() for faster iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,11 +106,14 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # ⚡ Bolt: Use itertuples() instead of iterrows() for faster iteration
+        for row in tqdm(
+            df_refs.itertuples(index=False), dataset, total=df_refs.shape[0]
+        ):
             atoms_list = []
-            identifier = row["Reaction"]
-            reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.
-            e_rel_ref = row["Reference"]
+            identifier = row.Reaction
+            reactions = row.Stoichiometry.split(",")  # Parse stoichiometry string.
+            e_rel_ref = row.Reference
             num_species = len(reactions) // 2  # Each species has coefficient and name.
 
             e_rel_model = 0


### PR DESCRIPTION
💡 **What:** Replaced `pandas.DataFrame.iterrows()` with `itertuples()` or `to_dict('records')` across the `calc_elasticity.py`, `gscdb138.py`, `calc_solvMPCONF196.py`, and `calc_MPCONF196.py` scripts.

🎯 **Why:** Iterating through a pandas DataFrame via `iterrows()` is a known performance anti-pattern. It creates a Series object for each row, adding significant overhead. `itertuples()` creates lightweight namedtuples (or standard tuples) which process much faster. `to_dict('records')` creates standard Python dictionaries, effectively bypassing pandas Series overhead for field-based access.

📊 **Impact:** Should significantly reduce the iteration time over these dataframes, improving the calculation scripts' overall performance, particularly on larger datasets.

🔬 **Measurement:** Verify tests run properly. Any profiling applied to the dataset loops should demonstrate a stark reduction in iteration execution time.

---
*PR created automatically by Jules for task [11303243835035267442](https://jules.google.com/task/11303243835035267442) started by @alinelena*