### PR TITLE
⚡ Bolt: optimize disk I/O and redundant loops in MPCONF196 conformer benchmarks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-19 - Caching ase.Atoms and Clearing Metadata for I/O
+**Learning:** Re-reading the same XYZ files within nested conformer loops (like in MPCONF196 benchmarks) is a significant disk I/O bottleneck. Caching `ase.Atoms` objects in a list during the first pass avoids this. However, to preserve translations and correctly output just the structure (without stale energy/forces metadata), you MUST explicitly clear the calculator (`atoms.calc = None`) before writing to disk using `ase.io.write`.
+**Action:** When reusing `ase.Atoms` objects across calculation loops, cache them to avoid duplicate disk reads, but always set `atoms.calc = None` prior to final structure serialization if clean output is required.

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -122,6 +122,7 @@ def test_mpconf196(mlip: tuple[str, Any]) -> None:
         model_abs_energies = []
         ref_abs_energies = []
         current_molecule_labels = []
+        current_molecule_atoms = []
 
         # Get reference and predicted energy for each conformer
         for label, e_ref in ref_energies.items():
@@ -143,23 +144,24 @@ def test_mpconf196(mlip: tuple[str, Any]) -> None:
                 model_abs_energies.append(np.nan)
             ref_abs_energies.append(e_ref)
             current_molecule_labels.append(label)
+            current_molecule_atoms.append(atoms)
+
+        # ⚡ Bolt: Hoist O(N) mean calculations out of loop to avoid O(N^2) complexity
+        mean_ref_abs_energy = np.mean(ref_abs_energies)
+        mean_model_abs_energy = np.mean(model_abs_energies)
 
         # Get energies relative to average conformer energies
-        for label, e_model in zip(
-            current_molecule_labels, model_abs_energies, strict=True
+        for label, e_model, atoms in zip(
+            current_molecule_labels,
+            model_abs_energies,
+            current_molecule_atoms,
+            strict=True,
         ):
-            molecule_label = label.split("_")[0]
-            conformer_label = label.split("_")[1]
-            if label[-1].isnumeric():
-                xyz_fname = f"{molecule_label}{conformer_label}.xyz"
-            else:
-                xyz_fname = f"{molecule_label}_{conformer_label}.xyz"
-            atoms = get_atoms(data_path / xyz_fname)
+            # ⚡ Bolt: Clear calc before disk write to avoid stale metadata
+            atoms.calc = None
             atoms.translate(-atoms.get_center_of_mass())
-            atoms.info["ref_rel_energy"] = ref_energies[label] - np.mean(
-                ref_abs_energies
-            )
-            atoms.info["model_rel_energy"] = e_model - np.mean(model_abs_energies)
+            atoms.info["ref_rel_energy"] = ref_energies[label] - mean_ref_abs_energy
+            atoms.info["model_rel_energy"] = e_model - mean_model_abs_energy
 
             write_dir = OUT_PATH / model_name
             write_dir.mkdir(parents=True, exist_ok=True)

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -121,6 +121,7 @@ def test_solvmpconf196(mlip: tuple[str, Any]) -> None:
         model_abs_energies = []
         ref_abs_energies = []
         current_molecule_labels = []
+        current_molecule_atoms = []
 
         # Get reference and predicted energy for each conformer
         for label, e_ref in ref_energies.items():
@@ -147,30 +148,24 @@ def test_solvmpconf196(mlip: tuple[str, Any]) -> None:
                 model_abs_energies.append(np.nan)
             ref_abs_energies.append(e_ref)
             current_molecule_labels.append(label)
+            current_molecule_atoms.append(atoms)
+
+        # ⚡ Bolt: Hoist O(N) mean calculations out of loop to avoid O(N^2) complexity
+        mean_ref_abs_energy = np.mean(ref_abs_energies)
+        mean_model_abs_energy = np.mean(model_abs_energies)
 
         # Get energies relative to average conformer energies
-        for label, e_model in zip(
-            current_molecule_labels, model_abs_energies, strict=False
+        for label, e_model, atoms in zip(
+            current_molecule_labels,
+            model_abs_energies,
+            current_molecule_atoms,
+            strict=False,
         ):
-            molecule_label = label.split("_")[0]
-            conformer_label = label.split("_")[1]
-            if label[-1].isnumeric():
-                xyz_label = f"{molecule_label}{conformer_label}"
-            else:
-                xyz_label = f"{molecule_label}_{conformer_label}"
-            if molecule != molecule_label:
-                continue
-            atoms = get_atoms(
-                data_path
-                / "solvMPCONF196_geometries/solvMPCONF196"
-                / xyz_label
-                / "struc.xyz"
-            )
+            # ⚡ Bolt: Clear calc before disk write to avoid stale metadata
+            atoms.calc = None
             atoms.translate(-atoms.get_center_of_mass())
-            atoms.info["ref_rel_energy"] = ref_energies[label] - np.mean(
-                ref_abs_energies
-            )
-            atoms.info["model_rel_energy"] = e_model - np.mean(model_abs_energies)
+            atoms.info["ref_rel_energy"] = ref_energies[label] - mean_ref_abs_energy
+            atoms.info["model_rel_energy"] = e_model - mean_model_abs_energy
 
             write_dir = OUT_PATH / model_name
             write_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
💡 What: Cached `ase.Atoms` objects in a list during the first conformer loop to prevent re-reading the same XYZ files from disk in the second loop. Additionally, hoisted `np.mean` calculations for absolute reference and model energies out of the inner loop, and explicitly cleared `atoms.calc = None` to ensure stale computation metadata isn't serialized.

🎯 Why: Reading XYZ structures repeatedly is a severe I/O bottleneck in conformer benchmarks. Also, calling `np.mean()` on a list inside an $O(N)$ loop creates redundant $O(N^2)$ computations. Clearing the calculator avoids writing stale evaluation forces/energies into the finalized structure file.

📊 Impact: Reduces disk reads for structure files by 50% for MPCONF196 and solvMPCONF196 datasets. Avoids redundant, unnecessary mathematical calculations inside loops, improving CPU performance for the loop stage from $O(N^2)$ to $O(N)$.

🔬 Measurement: Verify correctness and performance by running:
```bash
uv run pytest ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
uv run pytest ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
```

---
*PR created automatically by Jules for task [10159642491472133360](https://jules.google.com/task/10159642491472133360) started by @alinelena*