### PR TITLE
Return NaN for MAE of NaNs

### DIFF
--- a/ml_peg/analysis/utils/utils.py
+++ b/ml_peg/analysis/utils/utils.py
@@ -158,6 +158,8 @@ def mae(ref: list, prediction: list) -> float:
     float
         Mean absolute error.
     """
+    if np.isnan(np.sum(prediction)):
+        return np.nan
     return mean_absolute_error(ref, prediction)
 
 
@@ -177,6 +179,8 @@ def rmse(ref: list, prediction: list) -> float:
     float
         Root mean squared error.
     """
+    if np.isnan(np.sum(prediction)):
+        return np.nan
     return np.sqrt(mean_squared_error(ref, prediction))
 
 


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

If predictions contain NaN, currently `mae` throws an error. This checks if there are NaNs (sum is among the quickest ways to do this) and if there are, returns NaN.