### PR TITLE
Fix filter

### DIFF
--- a/ml_peg/analysis/utils/utils.py
+++ b/ml_peg/analysis/utils/utils.py
@@ -426,7 +426,6 @@ def calc_table_scores(
     weights: dict[str, float] | None = None,
     thresholds: Thresholds | None = None,
     normalizer: Callable[[float, float, float], float] | None = None,
-    require_all_metrics: bool = True,
     return_scores: bool = False,
 ) -> list[MetricRow] | tuple[list[MetricRow], list[MetricRow]]:
     """
@@ -446,10 +445,6 @@ def calc_table_scores(
     normalizer
         Optional function to map (value, good, bad) -> normalised score.
         If `None`, and thresholds are specified, uses `normalize_metric`.
-    require_all_metrics
-        If True, score is set to None unless all metrics are present (not None).
-        If False, score is calculated from available metrics only.
-        Default is True.
     return_scores
         If True, also return the normalised metric rows used to calculate scores.
         Default is False.

--- a/ml_peg/analysis/utils/utils.py
+++ b/ml_peg/analysis/utils/utils.py
@@ -475,22 +475,18 @@ def calc_table_scores(
     for metrics_row, scores_row in zip(metrics_data, metrics_scores, strict=True):
         weighted_sum = 0.0
         weight_sum = 0.0
-
-        all_metrics_present = True
         contains_nan = False
 
         for key in metric_columns:
-            if (weight := metric_weights[key]) == 0:
+            score = scores_row[key]
+            weight = metric_weights[key]
+
+            # If weight is zero or score is None, no contribution to overall score
+            if weight == 0 or score is None:
                 continue
 
-            value = metrics_row.get(key)
-            score = scores_row.get(key)
-
-            if value is None or score is None:
-                all_metrics_present = False
-                continue
-
-            if isinstance(score, float) and np.isnan(score):
+            # If score is NaN, overall score will be NaN
+            if (isinstance(score, float) and np.isnan(score)) or score == "NaN":
                 contains_nan = True
                 break
 
@@ -498,9 +494,7 @@ def calc_table_scores(
             weight_sum += weight
 
         if contains_nan:
-            metrics_row["Score"] = np.nan
-        elif require_all_metrics and not all_metrics_present:
-            metrics_row["Score"] = None
+            metrics_row["Score"] = "NaN"
         elif weight_sum > 0:
             metrics_row["Score"] = weighted_sum / weight_sum
         else:
@@ -625,7 +619,9 @@ def get_table_style(
             raw_value = row[col]
             # Track None values separately for styling
             is_none = raw_value is None
-            is_nan = isinstance(raw_value, float) and np.isnan(raw_value)
+            is_nan = (
+                isinstance(raw_value, float) and np.isnan(raw_value)
+            ) or raw_value == "NaN"
             if is_none or is_nan:
                 none_row_indices.append(i)
                 continue
@@ -663,7 +659,7 @@ def get_table_style(
                         "#d0d0d0 10px"
                         ")"
                     ),
-                    "color": "#888888",
+                    "color": "transparent",
                     "fontStyle": "italic",
                 }
             )
@@ -760,7 +756,7 @@ def normalize_metric(
 
     try:
         # Handle NaNs robustly
-        if np.isnan([value, good_threshold, bad_threshold]).any():
+        if np.isnan([value, good_threshold, bad_threshold]).any() or value == "NaN":
             return np.nan
     except TypeError:
         return np.nan

--- a/ml_peg/analysis/utils/utils.py
+++ b/ml_peg/analysis/utils/utils.py
@@ -613,23 +613,27 @@ def get_table_style(
     for col in cols:
         numeric_entries: list[tuple[object, float, float]] = []
         none_row_indices: list[int] = []  # Track rows with None values
+        nan_row_indices: list[int] = []  # Track rows with NaN values
         for i, row in enumerate(data):
             if col not in row:
                 continue
             raw_value = row[col]
-            # Track None values separately for styling
+            # Track missing values separately for styling
             is_none = raw_value is None
             is_nan = (
                 isinstance(raw_value, float) and np.isnan(raw_value)
             ) or raw_value == "NaN"
-            if is_none or is_nan:
+            if is_none:
                 none_row_indices.append(i)
+                continue
+            if is_nan:
+                nan_row_indices.append(i)
                 continue
             # Skip if unable to convert to float
             try:
                 numeric_value = float(raw_value)
             except (TypeError, ValueError):
-                none_row_indices.append(i)
+                nan_row_indices.append(i)
                 continue
 
             # Get scored value, if is exists
@@ -640,7 +644,7 @@ def get_table_style(
 
             numeric_entries.append((raw_value, numeric_value, scored_value))
 
-        # Apply styling for None/missing values: gray hashed pattern
+        # Apply styling for None values: gray hashed pattern
         for row_idx in none_row_indices:
             mlip_name = data[row_idx].get("MLIP", "")
             style_data_conditional.append(
@@ -657,6 +661,30 @@ def get_table_style(
                         "transparent 5px, "
                         "#d0d0d0 5px, "
                         "#d0d0d0 10px"
+                        ")"
+                    ),
+                    "color": "transparent",
+                    "fontStyle": "italic",
+                }
+            )
+
+        # Apply styling for NaN values: red-tinted hash
+        for row_idx in nan_row_indices:
+            mlip_name = data[row_idx].get("MLIP", "")
+            style_data_conditional.append(
+                {
+                    "if": {
+                        "filter_query": f"{{MLIP}} = '{mlip_name}'",
+                        "column_id": col,
+                    },
+                    "backgroundColor": "#f4e3e3",
+                    "backgroundImage": (
+                        "repeating-linear-gradient("
+                        "45deg, "
+                        "transparent, "
+                        "transparent 5px, "
+                        "#e6bcbc 5px, "
+                        "#e6bcbc 10px"
                         ")"
                     ),
                     "color": "transparent",

--- a/ml_peg/app/utils/load.py
+++ b/ml_peg/app/utils/load.py
@@ -19,6 +19,7 @@ from ml_peg.app.utils.utils import (
     clean_thresholds,
     clean_weights,
     is_numeric_column,
+    none_to_nan,
     sig_fig_format,
 )
 from ml_peg.models.get_models import get_model_names, load_model_configs
@@ -54,7 +55,10 @@ def rebuild_table(
         table_json = json.load(f)
 
     data = table_json["data"]
-    data = clean_table_data(data)
+    # Remove values greater than int64 limits
+    clean_table_data(data)
+    # Replace None scores with NaN
+    none_to_nan(data)
 
     columns = table_json["columns"]
     model_name_map = dict(table_json.get("model_name_map") or {})
@@ -80,18 +84,18 @@ def rebuild_table(
         col["id"] for col in columns if col.get("id") not in {"MLIP", "Score", "id"}
     ]
 
-    # Add missing models with None for all metrics
+    # Add missing models with NaN for all metrics
     for original_model in all_registry_models:
         # Convert original model name (from registry) to display name (for table)
         display_name = original_to_display.get(original_model, original_model)
         if display_name not in existing_display_names:
-            # Create row with None for all metrics (will appear grayed out) while
+            # Create row with NaN for all metrics (will appear hashed out) while
             # storing the original model name in ``id`` so callbacks have a stable key
             new_row = {"MLIP": display_name, "id": original_model}
             for metric in metric_columns:
-                new_row[metric] = None
-            # Score will be None (calculated later by calc_table_scores)
-            new_row["Score"] = None
+                new_row[metric] = "NaN"
+            # Score will be NaN (calculated later by calc_table_scores)
+            new_row["Score"] = "NaN"
             data.append(new_row)
 
             # Update model_name_map if this is a new model not in original JSON

--- a/ml_peg/app/utils/utils.py
+++ b/ml_peg/app/utils/utils.py
@@ -327,13 +327,15 @@ def clean_table_data(rows: list[dict]) -> list[dict]:
     Returns
     -------
     list[dict]
-        Cleaned table rows with values larger than int64 limits set to NaN.
+        Cleaned table rows with values larger than int64 limits or `None` set to NaN.
     """
     for row in rows:
         for key, value in row.items():
             if isinstance(value, int | float) and (
                 value > np.iinfo(np.int64).max or value < np.iinfo(np.int64).min
             ):
+                row[key] = np.nan
+            if value is None:
                 row[key] = np.nan
     return rows
 

--- a/ml_peg/app/utils/utils.py
+++ b/ml_peg/app/utils/utils.py
@@ -315,7 +315,7 @@ def clean_weights(raw_weights: dict[str, float] | None) -> dict[str, float]:
     return weights
 
 
-def clean_table_data(rows: list[dict]) -> list[dict]:
+def clean_table_data(rows: list[dict]):
     """
     Ensure data does not exceed int limits.
 
@@ -323,21 +323,30 @@ def clean_table_data(rows: list[dict]) -> list[dict]:
     ----------
     rows
         List of table rows to clean.
-
-    Returns
-    -------
-    list[dict]
-        Cleaned table rows with values larger than int64 limits or `None` set to NaN.
     """
     for row in rows:
         for key, value in row.items():
             if isinstance(value, int | float) and (
                 value > np.iinfo(np.int64).max or value < np.iinfo(np.int64).min
             ):
-                row[key] = np.nan
+                row[key] = "NaN"
             if value is None:
-                row[key] = np.nan
-    return rows
+                row[key] = "NaN"
+
+
+def none_to_nan(rows: list[dict]) -> None:
+    """
+    Replace None values with NaN.
+
+    Parameters
+    ----------
+    rows
+        List of table rows to replace None values in.
+    """
+    for row in rows:
+        for key, value in row.items():
+            if value is None or (isinstance(value, float) and np.isnan(value)):
+                row[key] = "NaN"
 
 
 def filter_rows_by_models(


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Fixes filtering so scores are calculated based on remaining values, rather than getting set to None/NaN.

While the `None` values we write out when we store the initial tables are preserved in the `table.json` files, when the same data is written to json for the `dcc.Store`, both `NaN` and `None` are set to `null`, and so are read back in as `None`.

I therefore use `"NaN"` are a `NaN`, and reserve `None` for filtered data. If a value is `NaN`, is blocks calculation of the total score, while if a value is `None`, it does not, and I added a new style to distinguish these cases.

I also remove the distinction between `None` and `NaN` in the initial tables, as these are all unfiltered, is are `"NaN"`s in this scheme.