### PR TITLE
⚡ Bolt: Replace slow iterrows() with itertuples() or to_dict('records')

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2026-06-12 - Pandas DataFrame Iteration Bottleneck
+**Learning:** Iterating over Pandas DataFrames with `iterrows()` is a significant performance bottleneck due to type inference and Pandas Series object creation overhead for every row.
+**Action:** Replace `iterrows()` with `itertuples(index=False, name=None)` for standard tuple-based iteration (fastest) or `to_dict('records')` if dictionary-like access via dynamic keys is required.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -301,7 +301,8 @@ def run_elasticity_benchmark(
         else {}
     )
     atoms_list = []
-    for _, row in results.iterrows():
+    # ⚡ Bolt: Replace iterrows() with to_dict('records') for faster iteration
+    for row in results.to_dict('records'):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             struct = mock_ref_map.get(row[benchmark.index_name])

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -302,7 +302,7 @@ def run_elasticity_benchmark(
     )
     atoms_list = []
     # ⚡ Bolt: Replace iterrows() with to_dict('records') for faster iteration
-    for row in results.to_dict('records'):
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             struct = mock_ref_map.get(row[benchmark.index_name])

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # ⚡ Bolt: Replace iterrows() with itertuples() for faster DataFrame iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # ⚡ Bolt: Replace iterrows() with itertuples() for faster DataFrame iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,7 +106,8 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # ⚡ Bolt: Replace iterrows() with to_dict('records') for faster iteration
+        for row in tqdm(df_refs.to_dict('records'), dataset, total=df_refs.shape[0]):
             atoms_list = []
             identifier = row["Reaction"]
             reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -107,7 +107,7 @@ def run_gscdb138(
 
         # Calculate relative energy for each entry.
         # ⚡ Bolt: Replace iterrows() with to_dict('records') for faster iteration
-        for row in tqdm(df_refs.to_dict('records'), dataset, total=df_refs.shape[0]):
+        for row in tqdm(df_refs.to_dict("records"), dataset, total=df_refs.shape[0]):
             atoms_list = []
             identifier = row["Reaction"]
             reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.


### PR DESCRIPTION
💡 What: Replaced Pandas `iterrows()` usage with faster `itertuples(index=False, name=None)` or `to_dict('records')` in the conformers, MPCONF196, solvMPCONF196, and gscdb138 calculation modules.
🎯 Why: `iterrows()` is notoriously slow because it creates a new Pandas Series for every single row. Bypassing this overhead by directly extracting standard tuples or dictionaries drastically improves the loop iteration speed.
📊 Impact: Reduces iteration time across large DataFrames (up to 10-80x faster loop execution based on standard pandas benchmarks).
🔬 Measurement: Run `uv run pytest tests/` and confirm that all conformer and bulk elasticity tests complete accurately while executing significantly faster.

---
*PR created automatically by Jules for task [5029533201917479157](https://jules.google.com/task/5029533201917479157) started by @alinelena*