### PR TITLE
⚡ Bolt: [performance improvement] Optimize MPCONF196 conformer calculations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-19 - Caching and Hoisting in Conformer Calculations
+**Learning:** Conformer energy calculations typically contain redundant file reads (e.g. using `read()` repeatedly for the same structure) and repeated `np.mean` calculations within nested loops, causing unnecessary I/O and computation overhead.
+**Action:** Cache structure objects (`ase.Atoms`) in a list during the first pass and reuse them. Hoist constant calculations like `np.mean` out of loops. When reusing `ase.Atoms` objects across loops, explicitly clear the calculator (`atoms.calc = None`) before disk output if a structure-only write is required, and ensure that original geometry-modifying operations are preserved right before writing to avoid functional regressions.

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -122,6 +122,7 @@ def test_mpconf196(mlip: tuple[str, Any]) -> None:
         model_abs_energies = []
         ref_abs_energies = []
         current_molecule_labels = []
+        current_atoms_list = []
 
         # Get reference and predicted energy for each conformer
         for label, e_ref in ref_energies.items():
@@ -143,23 +144,22 @@ def test_mpconf196(mlip: tuple[str, Any]) -> None:
                 model_abs_energies.append(np.nan)
             ref_abs_energies.append(e_ref)
             current_molecule_labels.append(label)
+            current_atoms_list.append(atoms)
+
+        # ⚡ Bolt: Cache structures and hoist mean calculation to prevent I/O
+        # and redundant math
+        mean_ref_abs_energies = np.mean(ref_abs_energies)
+        mean_model_abs_energies = np.mean(model_abs_energies)
 
         # Get energies relative to average conformer energies
-        for label, e_model in zip(
-            current_molecule_labels, model_abs_energies, strict=True
+        for label, e_model, atoms in zip(
+            current_molecule_labels, model_abs_energies, current_atoms_list, strict=True
         ):
-            molecule_label = label.split("_")[0]
-            conformer_label = label.split("_")[1]
-            if label[-1].isnumeric():
-                xyz_fname = f"{molecule_label}{conformer_label}.xyz"
-            else:
-                xyz_fname = f"{molecule_label}_{conformer_label}.xyz"
-            atoms = get_atoms(data_path / xyz_fname)
             atoms.translate(-atoms.get_center_of_mass())
-            atoms.info["ref_rel_energy"] = ref_energies[label] - np.mean(
-                ref_abs_energies
-            )
-            atoms.info["model_rel_energy"] = e_model - np.mean(model_abs_energies)
+            atoms.info["ref_rel_energy"] = ref_energies[label] - mean_ref_abs_energies
+            atoms.info["model_rel_energy"] = e_model - mean_model_abs_energies
+
+            atoms.calc = None
 
             write_dir = OUT_PATH / model_name
             write_dir.mkdir(parents=True, exist_ok=True)

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -121,6 +121,7 @@ def test_solvmpconf196(mlip: tuple[str, Any]) -> None:
         model_abs_energies = []
         ref_abs_energies = []
         current_molecule_labels = []
+        current_atoms_list = []
 
         # Get reference and predicted energy for each conformer
         for label, e_ref in ref_energies.items():
@@ -147,30 +148,25 @@ def test_solvmpconf196(mlip: tuple[str, Any]) -> None:
                 model_abs_energies.append(np.nan)
             ref_abs_energies.append(e_ref)
             current_molecule_labels.append(label)
+            current_atoms_list.append(atoms)
+
+        # ⚡ Bolt: Cache structures and hoist mean calculation to prevent I/O
+        # and redundant math
+        mean_ref_abs_energies = np.mean(ref_abs_energies)
+        mean_model_abs_energies = np.mean(model_abs_energies)
 
         # Get energies relative to average conformer energies
-        for label, e_model in zip(
-            current_molecule_labels, model_abs_energies, strict=False
+        for label, e_model, atoms in zip(
+            current_molecule_labels,
+            model_abs_energies,
+            current_atoms_list,
+            strict=False,
         ):
-            molecule_label = label.split("_")[0]
-            conformer_label = label.split("_")[1]
-            if label[-1].isnumeric():
-                xyz_label = f"{molecule_label}{conformer_label}"
-            else:
-                xyz_label = f"{molecule_label}_{conformer_label}"
-            if molecule != molecule_label:
-                continue
-            atoms = get_atoms(
-                data_path
-                / "solvMPCONF196_geometries/solvMPCONF196"
-                / xyz_label
-                / "struc.xyz"
-            )
             atoms.translate(-atoms.get_center_of_mass())
-            atoms.info["ref_rel_energy"] = ref_energies[label] - np.mean(
-                ref_abs_energies
-            )
-            atoms.info["model_rel_energy"] = e_model - np.mean(model_abs_energies)
+            atoms.info["ref_rel_energy"] = ref_energies[label] - mean_ref_abs_energies
+            atoms.info["model_rel_energy"] = e_model - mean_model_abs_energies
+
+            atoms.calc = None
 
             write_dir = OUT_PATH / model_name
             write_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
💡 What: 
- Introduced caching of `ase.Atoms` structures into `current_atoms_list` during the first pass of conformer iteration in both `calc_MPCONF196.py` and `calc_solvMPCONF196.py`.
- Hoisted `np.mean(ref_abs_energies)` and `np.mean(model_abs_energies)` outside the second loop.
- Properly cleared the retained `.calc` before writing structures to disk to emulate the original pure-geometry write state.

🎯 Why: 
- The original logic re-read the exact same XYZ files from disk inside the second loop and repeatedly recalculated the mean energies for each iteration, causing redundant file I/O operations and scaling $O(N^2)$ math operations unnecessarily. 

📊 Impact: 
- Reduces disk I/O overhead by 50% for these conformer datasets by eliminating the second disk read pass.
- Transforms an $O(N^2)$ repeated mean calculation into an $O(N)$ operation.

🔬 Measurement: 
- Run the calculation scripts `uv run pytest ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py` and observe functional equivalence but heavily reduced disk access times.

---
*PR created automatically by Jules for task [7687471340423708876](https://jules.google.com/task/7687471340423708876) started by @alinelena*