### PR TITLE
⚡ Bolt: [performance improvement] Optimize DataFrame iterations and redundant disk IO

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-20 - Pandas iteration and redundant IO in nested loops
+**Learning:** Using `iterrows()` is a known pandas bottleneck. When iterating through structures, reading `ase.Atoms` repeatedly inside inner loops multiplies the IO penalty, especially when operations like `translate()` are re-run on identically read files.
+**Action:** Always replace `iterrows()` with `itertuples()` or `to_dict('records')` for faster row access. Cache `ase.Atoms` objects in lists when processing them in multi-pass loops to prevent redundant disk IO and repeated calculations.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -301,7 +301,8 @@ def run_elasticity_benchmark(
         else {}
     )
     atoms_list = []
-    for _, row in results.iterrows():
+    # ⚡ Bolt: Use to_dict('records') over iterrows for faster iteration
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             struct = mock_ref_map.get(row[benchmark.index_name])

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # ⚡ Bolt: Use itertuples over iterrows for faster iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 
@@ -122,6 +123,9 @@ def test_mpconf196(mlip: tuple[str, Any]) -> None:
         model_abs_energies = []
         ref_abs_energies = []
         current_molecule_labels = []
+        # ⚡ Bolt: Cache atoms to avoid redundant disk I/O and
+        # structure re-processing in loop 2
+        current_atoms = []
 
         # Get reference and predicted energy for each conformer
         for label, e_ref in ref_energies.items():
@@ -144,22 +148,20 @@ def test_mpconf196(mlip: tuple[str, Any]) -> None:
             ref_abs_energies.append(e_ref)
             current_molecule_labels.append(label)
 
+            # Explicitly clear calculator before caching
+            atoms.calc = None
+            current_atoms.append(atoms)
+
+        # ⚡ Bolt: Hoist constant mean computations out of the inner loop
+        mean_ref_abs_energy = np.mean(ref_abs_energies)
+        mean_model_abs_energy = np.mean(model_abs_energies)
+
         # Get energies relative to average conformer energies
-        for label, e_model in zip(
-            current_molecule_labels, model_abs_energies, strict=True
+        for label, e_model, atoms in zip(
+            current_molecule_labels, model_abs_energies, current_atoms, strict=True
         ):
-            molecule_label = label.split("_")[0]
-            conformer_label = label.split("_")[1]
-            if label[-1].isnumeric():
-                xyz_fname = f"{molecule_label}{conformer_label}.xyz"
-            else:
-                xyz_fname = f"{molecule_label}_{conformer_label}.xyz"
-            atoms = get_atoms(data_path / xyz_fname)
-            atoms.translate(-atoms.get_center_of_mass())
-            atoms.info["ref_rel_energy"] = ref_energies[label] - np.mean(
-                ref_abs_energies
-            )
-            atoms.info["model_rel_energy"] = e_model - np.mean(model_abs_energies)
+            atoms.info["ref_rel_energy"] = ref_energies[label] - mean_ref_abs_energy
+            atoms.info["model_rel_energy"] = e_model - mean_model_abs_energy
 
             write_dir = OUT_PATH / model_name
             write_dir.mkdir(parents=True, exist_ok=True)

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # ⚡ Bolt: Use itertuples over iterrows for faster iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies
@@ -121,6 +122,9 @@ def test_solvmpconf196(mlip: tuple[str, Any]) -> None:
         model_abs_energies = []
         ref_abs_energies = []
         current_molecule_labels = []
+        # ⚡ Bolt: Cache atoms to avoid redundant disk I/O and
+        # structure re-processing in loop 2
+        current_atoms = []
 
         # Get reference and predicted energy for each conformer
         for label, e_ref in ref_energies.items():
@@ -148,29 +152,20 @@ def test_solvmpconf196(mlip: tuple[str, Any]) -> None:
             ref_abs_energies.append(e_ref)
             current_molecule_labels.append(label)
 
+            # Explicitly clear calculator before caching
+            atoms.calc = None
+            current_atoms.append(atoms)
+
+        # ⚡ Bolt: Hoist constant mean computations out of the inner loop
+        mean_ref_abs_energy = np.mean(ref_abs_energies)
+        mean_model_abs_energy = np.mean(model_abs_energies)
+
         # Get energies relative to average conformer energies
-        for label, e_model in zip(
-            current_molecule_labels, model_abs_energies, strict=False
+        for label, e_model, atoms in zip(
+            current_molecule_labels, model_abs_energies, current_atoms, strict=False
         ):
-            molecule_label = label.split("_")[0]
-            conformer_label = label.split("_")[1]
-            if label[-1].isnumeric():
-                xyz_label = f"{molecule_label}{conformer_label}"
-            else:
-                xyz_label = f"{molecule_label}_{conformer_label}"
-            if molecule != molecule_label:
-                continue
-            atoms = get_atoms(
-                data_path
-                / "solvMPCONF196_geometries/solvMPCONF196"
-                / xyz_label
-                / "struc.xyz"
-            )
-            atoms.translate(-atoms.get_center_of_mass())
-            atoms.info["ref_rel_energy"] = ref_energies[label] - np.mean(
-                ref_abs_energies
-            )
-            atoms.info["model_rel_energy"] = e_model - np.mean(model_abs_energies)
+            atoms.info["ref_rel_energy"] = ref_energies[label] - mean_ref_abs_energy
+            atoms.info["model_rel_energy"] = e_model - mean_model_abs_energy
 
             write_dir = OUT_PATH / model_name
             write_dir.mkdir(parents=True, exist_ok=True)

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,7 +106,8 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # ⚡ Bolt: Use to_dict('records') over iterrows for faster iteration
+        for row in tqdm(df_refs.to_dict("records"), dataset, total=df_refs.shape[0]):
             atoms_list = []
             identifier = row["Reaction"]
             reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.


### PR DESCRIPTION
💡 What: Replaced slow `iterrows()` calls with `itertuples()` or `to_dict('records')`. Cached `ase.Atoms` objects in a list for multi-pass loops and hoisted invariant `np.mean` calculations.
🎯 Why: `iterrows()` is notoriously slow due to series object creation per row. Re-reading identical structure files and calculating redundant means inside loops introduced O(N) penalties.
📊 Impact: Significantly faster execution of benchmark analysis scripts and generation of test data.
🔬 Measurement: Run the tests in `ml_peg/calcs/conformers/MPCONF196/` and `ml_peg/calcs/conformers/solvMPCONF196/` and observe speedups.

---
*PR created automatically by Jules for task [1894788864288597607](https://jules.google.com/task/1894788864288597607) started by @alinelena*