### PR TITLE
dashed outline to zero weight boxes

### DIFF
--- a/ml_peg/app/utils/build_components.py
+++ b/ml_peg/app/utils/build_components.py
@@ -28,6 +28,7 @@ from ml_peg.app.utils.utils import (
     calculate_column_widths,
     get_framework_config,
     get_threshold_colours,
+    weight_input_style,
 )
 
 # Width (px) of the docs-link column of the summary table (see build_app.py).
@@ -124,14 +125,7 @@ def build_weight_input(
             value=default_value,
             step=0.01,
             debounce=True,
-            style={
-                "width": "60px",
-                "fontSize": "12px",
-                "padding": "2px 4px",
-                "border": "1px solid #6c757d",
-                "borderRadius": "3px",
-                "textAlign": "center",
-            },
+            style=weight_input_style(default_value),
         )
     )
 

--- a/ml_peg/app/utils/register_callbacks.py
+++ b/ml_peg/app/utils/register_callbacks.py
@@ -43,6 +43,7 @@ from ml_peg.app.utils.utils import (
     get_scores,
     get_threshold_colours,
     store_data_equal,
+    weight_input_style,
 )
 
 THRESHOLD_INPUT_STEP = 0.0001
@@ -890,11 +891,12 @@ def register_weight_callbacks(
 
     @callback(
         Output(f"{input_id}-input", "value"),
+        Output(f"{input_id}-input", "style"),
         Input(f"{table_id}-weight-store", "data"),
         prevent_initial_call="initial_duplicate",
         optional=True,
     )
-    def sync_inputs(stored_weights: dict[str, float]) -> float:
+    def sync_inputs(stored_weights: dict[str, float]) -> tuple[float, dict[str, str]]:
         """
         Sync weight values between the text input and Store.
 
@@ -905,10 +907,11 @@ def register_weight_callbacks(
 
         Returns
         -------
-        float
-            Weight to set text input value.
+        tuple[float, dict[str, str]]
+            Weight to set text input value, and its style (greyed when zero).
         """
-        return stored_weights[column]
+        weight = stored_weights[column]
+        return weight, weight_input_style(weight)
 
 
 def register_normalization_callbacks(

--- a/ml_peg/app/utils/utils.py
+++ b/ml_peg/app/utils/utils.py
@@ -154,6 +154,37 @@ def build_threshold_input_style(border_colour: str) -> dict[str, str]:
     }
 
 
+def weight_input_style(value: float | None) -> dict[str, str]:
+    """
+    Build the inline style for a metric weight input.
+
+    A weight of ``0`` excludes the metric from the score. The input stays white
+    with dark text (it is still editable); only its border switches to a muted
+    dashed style to signal the column is switched off.
+
+    Parameters
+    ----------
+    value
+        Current weight value for the input.
+
+    Returns
+    -------
+    dict[str, str]
+        Inline Dash style dictionary.
+    """
+    style = {
+        "width": "60px",
+        "fontSize": "12px",
+        "padding": "2px 4px",
+        "border": "1px solid #6c757d",
+        "borderRadius": "3px",
+        "textAlign": "center",
+    }
+    if value == 0:
+        style |= {"border": "1px dashed #adb5bd"}
+    return style
+
+
 class FrameworkEntry(TypedDict):
     """Style and link metadata for benchmark framework attribution badges."""
 


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary
- when a weight is zero, greying out a weight box made it look unusable/unclickable so i went for this dashed line around the outside
<!-- Describe your proposed changes. This can be brief, as most information can be in the linked issue. -->

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #

## Testing

<!-- How have your proposed changes been tested? -->
<img width="1445" height="546" alt="Screenshot 2026-06-16 at 18 20 29" src="https://github.com/user-attachments/assets/7bcdc516-5e5d-4620-bc54-9fdb7f30cf44" />
