### PR TITLE
Add test option for ml_peg app

### DIFF
--- a/ml_peg/app/build_app.py
+++ b/ml_peg/app/build_app.py
@@ -352,6 +352,7 @@ def build_sidebar(
 
 def get_all_tests(
     category: str = "*",
+    test: str = "*",
 ) -> tuple[
     dict[str, dict[str, Dash]],
     dict[str, dict[str, list[Div]]],
@@ -365,6 +366,8 @@ def get_all_tests(
     ----------
     category
         Name of category directory to search for tests. Default is '*'.
+    test
+        Name of test directory to search for. Default is '*'.
 
     Returns
     -------
@@ -374,7 +377,7 @@ def get_all_tests(
     # Find Python files e.g. app_OC157.py in mlip_tesing.app module.
     # We will get the category from the parent's parent directory
     # E.g. ml_peg/app/surfaces/OC157/app_OC157.py -> surfaces
-    tests = APP_ROOT.glob(f"{category}/*/app*.py")
+    tests = APP_ROOT.glob(f"{category}/{test}/app*.py")
     apps = {}
     layouts = {}
     tables = {}
@@ -1283,7 +1286,7 @@ def build_nav(
         )
 
 
-def build_full_app(full_app: Dash, category: str = "*") -> None:
+def build_full_app(full_app: Dash, category: str = "*", test: str = "*") -> None:
     """
     Build full app layout and register callbacks.
 
@@ -1293,9 +1296,13 @@ def build_full_app(full_app: Dash, category: str = "*") -> None:
         Full application with all sub-apps.
     category
         Category to build app for. Default is `*`, corresponding to all categories.
+    test
+        Test to build app for. Default is `*`, corresponding to all tests.
     """
     # Get layouts and tables for each test, grouped by categories
-    all_apps, all_layouts, all_tables, all_frameworks = get_all_tests(category=category)
+    all_apps, all_layouts, all_tables, all_frameworks = get_all_tests(
+        category=category, test=test
+    )
 
     if not all_layouts:
         raise ValueError("No tests were built successfully")

--- a/ml_peg/app/run_app.py
+++ b/ml_peg/app/run_app.py
@@ -12,7 +12,7 @@ from ml_peg.app.build_app import build_full_app
 DATA_PATH = Path(__file__).parent / "data"
 
 
-def _build_full_app(app: Dash, category: str):
+def _build_full_app(app: Dash, category: str, test: str):
     """
     Build full app layout and callbacks.
 
@@ -22,8 +22,10 @@ def _build_full_app(app: Dash, category: str):
         Dash application.
     category
         Category to build application for.
+    test
+        Test to build application for.
     """
-    build_full_app(app, category)
+    build_full_app(app, category, test)
 
 
 # Make server accessible for gunicorn
@@ -36,13 +38,14 @@ app = Dash(
 
 # Only build app when in production, otherwise run_app's layout is missing
 if bool(os.environ.get("ML_PEG_PROD", False)):
-    _build_full_app(app, "*")
+    _build_full_app(app, "*", "*")
 
 server = app.server
 
 
 def run_app(
     category: str = "*",
+    test: str = "*",
     port: int = 8050,
     debug: bool = False,
 ) -> None:
@@ -53,12 +56,14 @@ def run_app(
     ----------
     category
         Category to build app for. Default is `*`, corresponding to all categories.
+    test
+        Test to build app for. Default is `*`, corresponding to all tests.
     port
         Port to run application on. Default is 8050.
     debug
         Whether to run with Dash debugging. Default is `True`.
     """
-    _build_full_app(app, category=category)
+    _build_full_app(app, category=category, test=test)
 
     print(f"Starting Dash app on port {port}...")
     app.run(host="0.0.0.0", port=port, debug=debug)

--- a/ml_peg/cli/cli.py
+++ b/ml_peg/cli/cli.py
@@ -113,6 +113,13 @@ def run_dash_app(
             case_sensitive=False,
         ),
     ] = "*",
+    test: Annotated[
+        str,
+        Option(
+            help="Test to build app for. Default is all tests.",
+            case_sensitive=False,
+        ),
+    ] = "*",
     port: Annotated[str, Option(help="Port to run application on.")] = 8050,
     debug: Annotated[bool, Option(help="Whether to run with Dash debugging.")] = True,
 ) -> None:
@@ -128,6 +135,8 @@ def run_dash_app(
         Path to model definitions YAML file. Default is models.yml in models directory.
     category
         Category to build app for. Default is `*`, corresponding to all categories.
+    test
+        Test to build app for. Default is `*`, corresponding to all tests.
     port
         Port to run application on. Default is 8050.
     debug
@@ -141,7 +150,7 @@ def run_dash_app(
 
     from ml_peg.app.run_app import run_app
 
-    run_app(category=category, port=port, debug=debug)
+    run_app(category=category, test=test, port=port, debug=debug)
 
 
 @app.command(


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Add option to run individual benchmark apps.

With the changes for filtering, the logic for updating category summary tables, as well as the new logic for filtering, are done as part of the overall `run_app`, so do not work if individual apps are launched directly.

We should probably remove the `if __name__ == "__main__":` sections from apps to discourage this, but for now, this enables the possibility of launching them individually with full functionality.