### PR TITLE
add full screen ml-peg loading on start up

### DIFF
--- a/ml_peg/app/build_app.py
+++ b/ml_peg/app/build_app.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from importlib import import_module
 import warnings
 
-from dash import Dash, Input, Output, callback, ctx, no_update
+from dash import Dash, Input, Output, callback, clientside_callback, ctx, no_update
 from dash.dash_table import DataTable
-from dash.dcc import Dropdown, Link, Loading, Location, Store
+from dash.dcc import Dropdown, Interval, Link, Loading, Location, Store
 from dash.exceptions import PreventUpdate
 from dash.html import H1, H3, A, Br, Details, Div, Img, Span, Summary
 from yaml import safe_load
@@ -1002,6 +1002,48 @@ def build_nav(
     ]
 
     full_layout = [
+        # Start-up mask: covers the page and tutorial with a spinner until the
+        # page is interactive, so the tutorial isn't shown on a still-rendering
+        # page where it feels frozen. Hidden by the callback below.
+        Div(
+            [
+                Div(
+                    style={
+                        "width": "52px",
+                        "height": "52px",
+                        "border": "5px solid #d0ebff",
+                        "borderTopColor": "#119DFF",
+                        "borderRadius": "50%",
+                        "animation": "ml-peg-spin 0.8s linear infinite",
+                        "boxSizing": "border-box",
+                    },
+                ),
+                Div(
+                    "Loading ML-PEG…",
+                    style={
+                        "fontSize": "16px",
+                        "fontWeight": "600",
+                        "color": "#212529",
+                    },
+                ),
+            ],
+            id="startup-mask",
+            style={
+                "position": "fixed",
+                "top": "0",
+                "right": "0",
+                "bottom": "0",
+                "left": "0",
+                "display": "flex",
+                "flexDirection": "column",
+                "alignItems": "center",
+                "justifyContent": "center",
+                "gap": "14px",
+                "backgroundColor": "#ffffff",
+                "zIndex": "2100",  # Above the onboarding modal (2000).
+            },
+        ),
+        Interval(id="startup-mask-poll", interval=250, n_intervals=0),
         build_onboarding_modal(),
         build_tutorial_button(),
         Location(id="app-location", refresh=False),
@@ -1115,6 +1157,24 @@ def build_nav(
     full_app.layout = Div(
         full_layout,
         style={"display": "flex", "flexDirection": "column", "minHeight": "100vh"},
+    )
+
+    # Hide the start-up mask once the page has rendered, or after a timeout as
+    # a safety net, then stop polling. Clientside, so it adds no server load.
+    clientside_callback(
+        """
+        function(n) {
+            var nu = window.dash_clientside.no_update;
+            var ready = document.querySelector('#page-content table tbody tr');
+            if (ready || n > 40) {
+                return [{'display': 'none'}, true];
+            }
+            return [nu, nu];
+        }
+        """,
+        Output("startup-mask", "style"),
+        Output("startup-mask-poll", "disabled"),
+        Input("startup-mask-poll", "n_intervals"),
     )
 
     @callback(

--- a/ml_peg/app/data/utils/dash_loading.css
+++ b/ml_peg/app/data/utils/dash_loading.css
@@ -1,0 +1,36 @@
+/* Replace Dash's stock top-left "Loading..." pre-hydration placeholder with a
+   centered ML-PEG loader matching the in-app page spinner. Assets CSS loads in
+   <head> before the app entry point, so this applies during the cold-start
+   window. The ml-peg-spin keyframe is defined in loading.css. */
+._dash-loading {
+    position: fixed;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 14px;
+    background: #ffffff;
+    z-index: 1400;
+    /* Hide the literal "Loading..." text node. */
+    font-size: 0;
+}
+
+._dash-loading::before {
+    content: "";
+    width: 52px;
+    height: 52px;
+    border: 5px solid #d0ebff;
+    border-top-color: #119dff;
+    border-radius: 50%;
+    box-sizing: border-box;
+    animation: ml-peg-spin 0.8s linear infinite;
+}
+
+._dash-loading::after {
+    content: "Loading ML-PEG…";
+    font-size: 16px;
+    font-weight: 600;
+    color: #212529;
+    font-family: sans-serif;
+}


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary
2 issues:
- on start up (usually cold start) dash has a mostly blank screen with "loading..." in the top right corner
- when the app first loads in, components take time to load and can be glitchy for the first 100 seconds e.g. wont let you click the tutorial next button for a while

added:
- full screen ml-peg loading spinner, which only shows the app once the components have loaded, so no glitchy behaviour


<!-- Describe your proposed changes. This can be brief, as most information can be in the linked issue. -->

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #

## Testing

<!-- How have your proposed changes been tested? -->

before:
<img width="1826" height="956" alt="Screenshot 2026-06-21 at 00 22 57" src="https://github.com/user-attachments/assets/cdfe2411-7585-431f-9743-78351979a2e1" />


after:
<img width="1826" height="956" alt="Screenshot 2026-06-21 at 00 19 44" src="https://github.com/user-attachments/assets/4f6293c3-8aaf-4da0-8171-1ee75d98063e" />
