### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,7 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+
+## 2024-05-19 - Replacing Pandas iterrows() for Performance
+**Learning:** `df.iterrows()` is a known performance bottleneck in Pandas, as it yields a Series for each row, adding significant overhead compared to other iteration methods.
+**Action:** Replace `iterrows()` with `df.itertuples(index=False, name=None)` for standard tuple indexing, or `df.to_dict("records")` when dynamic/string keys are required. This provides a substantial speedup when iterating over DataFrame rows.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -301,7 +301,8 @@ def run_elasticity_benchmark(
         else {}
     )
     atoms_list = []
-    for _, row in results.iterrows():
+    # ⚡ Bolt: Replace slow iterrows() with to_dict() for faster DataFrame iteration
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             struct = mock_ref_map.get(row[benchmark.index_name])

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # ⚡ Bolt: Replace slow iterrows() with itertuples() for faster DataFrame iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # ⚡ Bolt: Replace slow iterrows() with itertuples() for faster DataFrame iteration
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,7 +106,8 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # ⚡ Bolt: Replace slow iterrows() with to_dict() for faster DataFrame iteration
+        for row in tqdm(df_refs.to_dict("records"), dataset, total=df_refs.shape[0]):
             atoms_list = []
             identifier = row["Reaction"]
             reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.


### PR DESCRIPTION
💡 **What**: Replaced slow `df.iterrows()` calls with `df.itertuples(index=False, name=None)` and `df.to_dict('records')` in several analysis/calculation scripts (`calc_MPCONF196.py`, `calc_solvMPCONF196.py`, `gscdb138.py`, `calc_elasticity.py`). Added a new entry to the `.jules/bolt.md` journal documenting this Pandas performance anti-pattern.
🎯 **Why**: `iterrows()` yields a Pandas Series for each row, adding immense overhead. `itertuples()` and `to_dict('records')` operate on standard python types, drastically speeding up iteration over DataFrames and reducing bottlenecks in the benchmark loops.
📊 **Impact**: Typical ~10-100x speedup for the specific loop execution times depending on the dataset size, completely bypassing the Pandas Series boxing overhead.
🔬 **Measurement**: Verified using inline `time` benchmarks simulating similar DataFrame structures and row accesses. Ensures all linting and test collectors continue to pass via `ruff check` and `pytest --collect-only`.

---
*PR created automatically by Jules for task [16349318821948778616](https://jules.google.com/task/16349318821948778616) started by @alinelena*