### PR TITLE
Fix Li diffusion metrics info

### DIFF
--- a/ml_peg/analysis/nebs/li_diffusion/metrics.yml
+++ b/ml_peg/analysis/nebs/li_diffusion/metrics.yml
@@ -1,13 +1,13 @@
 metrics:
   Path B error:
     good: 0.02
-    bad: 0.4
+    bad: 0.1
     unit: eV
     tooltip: "Energy barrier error for path B"
-    level_of_theory: r2SCAN
+    level_of_theory: Perdew-Wang
   Path C error:
-    good: 0.1
-    bad: 0.8
+    good: 0.02
+    bad: 1.0
     unit: eV
     tooltip: "Energy barrier error for path C"
-    level_of_theory: r2SCAN
+    level_of_theory: Perdew-Wang


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Fixes Li diffusion theory label, and updates thresholds to match the uncertainty of the DFT (20 meV) and order of magnitude changes to the diffusion coefficient for the lower barrier (the higher barrier threshold was then scaled to roughly match the relatively magnitude of energy).