### PR TITLE
feat: add grambow barrier heights benchmark

### DIFF
--- a/docs/source/user_guide/benchmarks/index.rst
+++ b/docs/source/user_guide/benchmarks/index.rst
@@ -18,4 +18,5 @@ Benchmarks
     tm_complexes
     conformers
     molecular_dynamics
+    molecular_reactions
     defect

--- a/docs/source/user_guide/benchmarks/molecular_reactions.rst
+++ b/docs/source/user_guide/benchmarks/molecular_reactions.rst
@@ -77,7 +77,7 @@ on clicking the barrier height column.
 Computational cost
 ------------------
 
-Medium: around 36,000 single point inference calls (three states per reaction).
+Medium: around 36,000 single point inference calls (three states per reaction). Minutes on CPU, tens of minutes to hours on GPU.
 
 Data availability
 -----------------

--- a/docs/source/user_guide/benchmarks/molecular_reactions.rst
+++ b/docs/source/user_guide/benchmarks/molecular_reactions.rst
@@ -77,7 +77,7 @@ on clicking the barrier height column.
 Computational cost
 ------------------
 
-Medium: around 36,000 single point inference calls (three states per reaction). Minutes on CPU, tens of minutes to hours on GPU.
+Medium: around 36,000 single point inference calls (three states per reaction). Minutes on GPU, tens of minutes to hours on CPU.
 
 Data availability
 -----------------

--- a/docs/source/user_guide/benchmarks/molecular_reactions.rst
+++ b/docs/source/user_guide/benchmarks/molecular_reactions.rst
@@ -41,3 +41,54 @@ Reference data:
 
 * Same as input data
 * DFT (r2SCAN)
+
+
+Grambow barrier heights
+=======================
+
+Summary
+-------
+
+Performance in predicting reaction barrier heights for elementary organic
+reactions from the Grambow dataset, comprising almost 12,000 reactant, product
+and transition state triplets of small neutral molecules containing H, C, N and
+O. The benchmark is targeted at barrier heights and reaction energies.
+
+Metrics
+-------
+
+1. Barrier height MAE
+
+For each reaction, a single point energy is computed for the reactant, product
+and transition state. The activation energy (barrier height) is the transition
+state energy minus the reactant energy, and the reaction energy is
+the product energy minus the reactant energy. The reported metrics are the mean
+absolute errors of the activation energy and the reaction energy against the
+reference.
+
+2. Grambow score
+
+The overall score is the mlipaudit soft-threshold score combining the
+activation energy and reaction energy errors.
+
+A density scatter plot shows the predicted against reference activation energies
+on clicking the barrier height column.
+
+Computational cost
+------------------
+
+Medium: around 36,000 single point inference calls (three states per reaction).
+
+Data availability
+-----------------
+
+Input structures:
+
+* Grambow, C.A., Pattanaik, L. & Green, W.H. Reactants, products, and
+  transition states of elementary chemical reactions based on quantum
+  chemistry. Sci Data 7, 137 (2020). DOI: 10.1038/s41597-020-0460-4
+
+Reference data:
+
+* Same as input data
+* :math:`\omega B97X-D3/def2-TZVP` level of theory.

--- a/ml_peg/analysis/molecular_reactions/grambow_barrier_heights/analyse_grambow_barrier_heights.py
+++ b/ml_peg/analysis/molecular_reactions/grambow_barrier_heights/analyse_grambow_barrier_heights.py
@@ -1,0 +1,259 @@
+"""
+Analyse the Grambow reaction barrier benchmark.
+
+Grambow, C.A., Pattanaik, L. & Green, W.H.
+Reactants, products, and transition states of elementary chemical reactions
+based on quantum chemistry.
+Sci Data 7, 137 (2020).
+DOI: 10.1038/s41597-020-0460-4
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ase.calculators.calculator import Calculator
+from mlipaudit.benchmarks.reactivity.reactivity import ReactivityModelOutput
+import pytest
+
+from ml_peg.analysis.utils.decorators import build_table, plot_density_scatter
+from ml_peg.analysis.utils.utils import build_dispersion_name_map, load_metrics_config
+from ml_peg.app import APP_ROOT
+from ml_peg.calcs import CALCS_ROOT
+from ml_peg.calcs.utils.mlipaudit import MlPegGrambowBarrierHeightsBenchmark
+from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_models
+
+MODELS = load_models(current_models)
+DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)
+
+CALC_PATH = CALCS_ROOT / "molecular_reactions" / "grambow_barrier_heights" / "outputs"
+OUT_PATH = APP_ROOT / "data" / "molecular_reactions" / "grambow_barrier_heights"
+
+METRICS_CONFIG_PATH = Path(__file__).with_name("metrics.yml")
+DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
+    METRICS_CONFIG_PATH
+)
+
+
+@pytest.fixture
+def analyze_results() -> dict:
+    """
+    Run the mlipaudit analysis for each model.
+
+    Returns
+    -------
+    dict
+        Mapping of model name to its ``ReactivityResult``.
+    """
+    data_input_dir = download_s3_data(
+        key="inputs/molecular_reactions/grambow_barrier_heights/grambow_barrier_heights.zip",
+        filename="grambow_barrier_heights.zip",
+    )
+
+    results = {}
+    for model_name in MODELS:
+        path = CALC_PATH / model_name / "model_output.json"
+        if not path.exists():
+            continue
+        benchmark = MlPegGrambowBarrierHeightsBenchmark(
+            force_field=Calculator(),
+            data_input_dir=data_input_dir,
+            run_mode="standard",
+        )
+        benchmark.model_output = ReactivityModelOutput.model_validate_json(
+            path.read_text()
+        )
+        results[model_name] = benchmark.analyze()
+    return results
+
+
+@pytest.fixture
+def struct_info() -> dict:
+    """
+    Write the combined element set to ``info.json`` for filtering.
+
+    Returns
+    -------
+    dict
+        Mapping with the sorted list of elements present in the dataset.
+    """
+    data_input_dir = download_s3_data(
+        key="inputs/molecular_reactions/grambow_barrier_heights/grambow_barrier_heights.zip",
+        filename="grambow_barrier_heights.zip",
+    )
+    benchmark = MlPegGrambowBarrierHeightsBenchmark(
+        force_field=Calculator(),
+        data_input_dir=data_input_dir,
+        run_mode="standard",
+    )
+    elements = sorted(
+        {
+            symbol
+            for reaction in benchmark._grambow_data.values()
+            for molecule in (
+                reaction.reactants,
+                reaction.products,
+                reaction.transition_state,
+            )
+            for symbol in molecule.atom_symbols
+        }
+    )
+    info = {"elements": elements}
+    OUT_PATH.mkdir(parents=True, exist_ok=True)
+    (OUT_PATH / "info.json").write_text(json.dumps(info, indent=1))
+    return info
+
+
+@pytest.fixture
+@plot_density_scatter(
+    filename=OUT_PATH / "figure_barrier_density.json",
+    title="Reaction barrier density plot",
+    x_label="Reference activation energy / kcal/mol",
+    y_label="Predicted activation energy / kcal/mol",
+    annotation_metadata={"system_count": "Reactions"},
+)
+def barrier_density(analyze_results) -> dict[str, dict]:
+    """
+    Density scatter inputs for the reaction barrier heights.
+
+    Parameters
+    ----------
+    analyze_results
+        Mapping of model name to its ``ReactivityResult``.
+
+    Returns
+    -------
+    dict[str, dict]
+        Mapping of model name to density-scatter data.
+    """
+    density_inputs: dict[str, dict] = {}
+    for model_name, result in analyze_results.items():
+        reactions = result.reaction_results.values()
+        ref = [reaction.activation_energy_ref for reaction in reactions]
+        pred = [reaction.activation_energy_pred for reaction in reactions]
+        density_inputs[model_name] = {
+            "ref": ref,
+            "pred": pred,
+            "meta": {"system_count": len(pred)},
+        }
+    return density_inputs
+
+
+@pytest.fixture
+def get_barrier_mae(analyze_results) -> dict[str, float]:
+    """
+    Get the activation energy (barrier height) MAE for each model.
+
+    Parameters
+    ----------
+    analyze_results
+        Mapping of model name to its ``ReactivityResult``.
+
+    Returns
+    -------
+    dict[str, float]
+        Mean absolute activation energy error in kcal/mol for each model.
+    """
+    return {
+        model_name: result.mae_activation_energy
+        for model_name, result in analyze_results.items()
+    }
+
+
+@pytest.fixture
+def get_reaction_energy_mae(analyze_results) -> dict[str, float]:
+    """
+    Get the reaction energy (enthalpy) MAE for each model.
+
+    Parameters
+    ----------
+    analyze_results
+        Mapping of model name to its ``ReactivityResult``.
+
+    Returns
+    -------
+    dict[str, float]
+        Mean absolute enthalpy of reaction error in kcal/mol for each model.
+    """
+    return {
+        model_name: result.mae_enthalpy_of_reaction
+        for model_name, result in analyze_results.items()
+    }
+
+
+@pytest.fixture
+def get_score(analyze_results) -> dict[str, float]:
+    """
+    Get the mlipaudit benchmark score for each model.
+
+    Parameters
+    ----------
+    analyze_results
+        Mapping of model name to its ``ReactivityResult``.
+
+    Returns
+    -------
+    dict[str, float]
+        The mlipaudit soft-threshold score (0 to 1) for each model.
+    """
+    return {model_name: result.score for model_name, result in analyze_results.items()}
+
+
+@pytest.fixture
+@build_table(
+    filename=OUT_PATH / "grambow_barrier_heights_metrics_table.json",
+    metric_tooltips=DEFAULT_TOOLTIPS,
+    thresholds=DEFAULT_THRESHOLDS,
+    weights=DEFAULT_WEIGHTS,
+    mlip_name_map=DISPERSION_NAME_MAP,
+)
+def metrics(
+    barrier_density,
+    get_barrier_mae: dict[str, float],
+    get_reaction_energy_mae: dict[str, float],
+    get_score: dict[str, float],
+) -> dict[str, dict]:
+    """
+    Get all metrics.
+
+    Parameters
+    ----------
+    barrier_density
+        Density scatter inputs for the reaction barriers (triggers the plot).
+    get_barrier_mae
+        Activation energy MAEs for all models.
+    get_reaction_energy_mae
+        Reaction energy MAEs for all models.
+    get_score
+        The mlipaudit benchmark scores for all models.
+
+    Returns
+    -------
+    dict[str, dict]
+        Metric names and values for all models.
+    """
+    return {
+        "Barrier Height MAE": get_barrier_mae,
+        "Reaction Energy MAE": get_reaction_energy_mae,
+        "Grambow Score": get_score,
+    }
+
+
+def test_grambow_barrier_heights(
+    metrics: dict[str, dict], barrier_density: dict[str, dict], struct_info: dict
+) -> None:
+    """
+    Run Grambow barrier heights analysis.
+
+    Parameters
+    ----------
+    metrics : dict[str, dict]
+        Grambow barrier heights metric results provided by fixtures.
+    barrier_density : dict[str, dict]
+        Density scatter inputs for the reaction barriers.
+    struct_info : dict
+        Element info written to ``info.json`` for filtering.
+    """

--- a/ml_peg/analysis/molecular_reactions/grambow_barrier_heights/analyse_grambow_barrier_heights.py
+++ b/ml_peg/analysis/molecular_reactions/grambow_barrier_heights/analyse_grambow_barrier_heights.py
@@ -14,15 +14,16 @@ import json
 from pathlib import Path
 
 from ase.calculators.calculator import Calculator
-from mlipaudit.benchmarks.reactivity.reactivity import ReactivityModelOutput
 import pytest
+
+pytest.importorskip("mlipaudit", reason="Please install `mlipaudit` extra")
+from mlipaudit.benchmarks.reactivity.reactivity import ReactivityModelOutput
 
 from ml_peg.analysis.utils.decorators import build_table, plot_density_scatter
 from ml_peg.analysis.utils.utils import build_dispersion_name_map, load_metrics_config
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
 from ml_peg.calcs.utils.mlipaudit import MlPegGrambowBarrierHeightsBenchmark
-from ml_peg.calcs.utils.utils import download_s3_data
 from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
 
@@ -48,11 +49,6 @@ def analyze_results() -> dict:
     dict
         Mapping of model name to its ``ReactivityResult``.
     """
-    data_input_dir = download_s3_data(
-        key="inputs/molecular_reactions/grambow_barrier_heights/grambow_barrier_heights.zip",
-        filename="grambow_barrier_heights.zip",
-    )
-
     results = {}
     for model_name in MODELS:
         path = CALC_PATH / model_name / "model_output.json"
@@ -60,7 +56,7 @@ def analyze_results() -> dict:
             continue
         benchmark = MlPegGrambowBarrierHeightsBenchmark(
             force_field=Calculator(),
-            data_input_dir=data_input_dir,
+            data_input_dir=CALC_PATH,
             run_mode="standard",
         )
         benchmark.model_output = ReactivityModelOutput.model_validate_json(
@@ -80,13 +76,9 @@ def struct_info() -> dict:
     dict
         Mapping with the sorted list of elements present in the dataset.
     """
-    data_input_dir = download_s3_data(
-        key="inputs/molecular_reactions/grambow_barrier_heights/grambow_barrier_heights.zip",
-        filename="grambow_barrier_heights.zip",
-    )
     benchmark = MlPegGrambowBarrierHeightsBenchmark(
         force_field=Calculator(),
-        data_input_dir=data_input_dir,
+        data_input_dir=CALC_PATH,
         run_mode="standard",
     )
     elements = sorted(

--- a/ml_peg/analysis/molecular_reactions/grambow_barrier_heights/analyse_grambow_barrier_heights.py
+++ b/ml_peg/analysis/molecular_reactions/grambow_barrier_heights/analyse_grambow_barrier_heights.py
@@ -13,14 +13,20 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ase import Atoms
 from ase.calculators.calculator import Calculator
+from ase.io import write
 import pytest
 
 pytest.importorskip("mlipaudit", reason="Please install `mlipaudit` extra")
 from mlipaudit.benchmarks.reactivity.reactivity import ReactivityModelOutput
 
 from ml_peg.analysis.utils.decorators import build_table, plot_density_scatter
-from ml_peg.analysis.utils.utils import build_dispersion_name_map, load_metrics_config
+from ml_peg.analysis.utils.utils import (
+    build_dispersion_name_map,
+    load_metrics_config,
+    sample_density_grid,
+)
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
 from ml_peg.calcs.utils.mlipaudit import MlPegGrambowBarrierHeightsBenchmark
@@ -47,7 +53,7 @@ def analyze_results() -> dict:
     Returns
     -------
     dict
-        Mapping of model name to its ``ReactivityResult``.
+        Mapping of model name to ``(benchmark, ReactivityResult)``.
     """
     results = {}
     for model_name in MODELS:
@@ -62,7 +68,7 @@ def analyze_results() -> dict:
         benchmark.model_output = ReactivityModelOutput.model_validate_json(
             path.read_text()
         )
-        results[model_name] = benchmark.analyze()
+        results[model_name] = (benchmark, benchmark.analyze())
     return results
 
 
@@ -114,7 +120,7 @@ def barrier_density(analyze_results) -> dict[str, dict]:
     Parameters
     ----------
     analyze_results
-        Mapping of model name to its ``ReactivityResult``.
+        Mapping of model name to ``(benchmark, ReactivityResult)``.
 
     Returns
     -------
@@ -122,10 +128,27 @@ def barrier_density(analyze_results) -> dict[str, dict]:
         Mapping of model name to density-scatter data.
     """
     density_inputs: dict[str, dict] = {}
-    for model_name, result in analyze_results.items():
-        reactions = result.reaction_results.values()
-        ref = [reaction.activation_energy_ref for reaction in reactions]
-        pred = [reaction.activation_energy_pred for reaction in reactions]
+    for model_name, (benchmark, result) in analyze_results.items():
+        ref: list[float] = []
+        pred: list[float] = []
+        ts_atoms: list[Atoms] = []
+        for reaction_id, reaction in result.reaction_results.items():
+            ref.append(reaction.activation_energy_ref)
+            pred.append(reaction.activation_energy_pred)
+            ts = benchmark._grambow_data[reaction_id].transition_state
+            ts_atoms.append(Atoms(symbols=ts.atom_symbols, positions=ts.coordinates))
+
+        # Write one trajectory per sampled density point, grouping the transition
+        # states of the reactions that share that point's density cell
+        _, _, sampled_mapping = sample_density_grid(ref, pred)
+        traj_dir = OUT_PATH / model_name / "density_traj"
+        traj_dir.mkdir(parents=True, exist_ok=True)
+        for point_idx, source_indices in enumerate(sampled_mapping):
+            write(
+                traj_dir / f"{point_idx}.extxyz",
+                [ts_atoms[i] for i in source_indices],
+            )
+
         density_inputs[model_name] = {
             "ref": ref,
             "pred": pred,
@@ -142,7 +165,7 @@ def get_barrier_mae(analyze_results) -> dict[str, float]:
     Parameters
     ----------
     analyze_results
-        Mapping of model name to its ``ReactivityResult``.
+        Mapping of model name to ``(benchmark, ReactivityResult)``.
 
     Returns
     -------
@@ -151,7 +174,7 @@ def get_barrier_mae(analyze_results) -> dict[str, float]:
     """
     return {
         model_name: result.mae_activation_energy
-        for model_name, result in analyze_results.items()
+        for model_name, (_, result) in analyze_results.items()
     }
 
 
@@ -163,7 +186,7 @@ def get_reaction_energy_mae(analyze_results) -> dict[str, float]:
     Parameters
     ----------
     analyze_results
-        Mapping of model name to its ``ReactivityResult``.
+        Mapping of model name to ``(benchmark, ReactivityResult)``.
 
     Returns
     -------
@@ -172,7 +195,7 @@ def get_reaction_energy_mae(analyze_results) -> dict[str, float]:
     """
     return {
         model_name: result.mae_enthalpy_of_reaction
-        for model_name, result in analyze_results.items()
+        for model_name, (_, result) in analyze_results.items()
     }
 
 
@@ -184,14 +207,16 @@ def get_score(analyze_results) -> dict[str, float]:
     Parameters
     ----------
     analyze_results
-        Mapping of model name to its ``ReactivityResult``.
+        Mapping of model name to ``(benchmark, ReactivityResult)``.
 
     Returns
     -------
     dict[str, float]
         The mlipaudit soft-threshold score (0 to 1) for each model.
     """
-    return {model_name: result.score for model_name, result in analyze_results.items()}
+    return {
+        model_name: result.score for model_name, (_, result) in analyze_results.items()
+    }
 
 
 @pytest.fixture

--- a/ml_peg/analysis/molecular_reactions/grambow_barrier_heights/metrics.yml
+++ b/ml_peg/analysis/molecular_reactions/grambow_barrier_heights/metrics.yml
@@ -1,0 +1,22 @@
+metrics:
+  Barrier Height MAE:
+    good: 0.0
+    bad: 2.0
+    unit: kcal/mol
+    weight: 0
+    tooltip: Mean absolute error of the reaction activation energy (barrier height).
+    level_of_theory: wB97X-D3/def2-TZVP
+  Reaction Energy MAE:
+    good: 0.0
+    bad: 2.0
+    unit: kcal/mol
+    weight: 0
+    tooltip: Mean absolute error of the enthalpy of reaction.
+    level_of_theory: wB97X-D3/def2-TZVP
+  Grambow Score:
+    good: 1.0
+    bad: 0.0
+    unit: null
+    weight: 1
+    tooltip: mlipaudit soft-threshold score combining activation energy and reaction energy errors (failed reactions score 0).
+    level_of_theory: wB97X-D3/def2-TZVP

--- a/ml_peg/app/molecular_reactions/grambow_barrier_heights/app_grambow_barrier_heights.py
+++ b/ml_peg/app/molecular_reactions/grambow_barrier_heights/app_grambow_barrier_heights.py
@@ -1,0 +1,78 @@
+"""Run Grambow barrier heights benchmark app."""
+
+from __future__ import annotations
+
+from dash import Dash
+from dash.html import Div
+
+from ml_peg.app import APP_ROOT
+from ml_peg.app.base_app import BaseApp
+from ml_peg.app.utils.build_callbacks import plot_from_table_cell
+from ml_peg.app.utils.load import read_density_plot_for_model
+from ml_peg.models import current_models
+from ml_peg.models.get_models import get_model_names
+
+MODELS = get_model_names(current_models)
+BENCHMARK_NAME = "GrambowBarrierHeights"
+DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/molecular_reactions.html#grambow-barrier-heights"
+DATA_PATH = APP_ROOT / "data" / "molecular_reactions" / "grambow_barrier_heights"
+
+
+class GrambowBarrierHeightsApp(BaseApp):
+    """Grambow barrier heights benchmark app layout and callbacks."""
+
+    def register_callbacks(self) -> None:
+        """Register callbacks to app."""
+        density_plots: dict[str, dict] = {}
+        for model in MODELS:
+            graph = read_density_plot_for_model(
+                filename=DATA_PATH / "figure_barrier_density.json",
+                model=model,
+                id=f"{BENCHMARK_NAME}-{model}-barrier-figure",
+            )
+            if graph is not None:
+                density_plots[model] = {"Barrier Height MAE": graph}
+
+        plot_from_table_cell(
+            table_id=self.table_id,
+            plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
+            cell_to_plot=density_plots,
+        )
+
+
+def get_app() -> GrambowBarrierHeightsApp:
+    """
+    Get Grambow barrier heights benchmark app layout and callback registration.
+
+    Returns
+    -------
+    GrambowBarrierHeightsApp
+        Benchmark layout and callback registration.
+    """
+    return GrambowBarrierHeightsApp(
+        name="Grambow Barrier Heights",
+        framework_ids="mlip_audit",
+        description=(
+            "Performance in predicting reaction barrier heights (and reaction "
+            "energies) for elementary organic reactions from the Grambow "
+            "dataset. Reference data from wB97X-D3/def2-TZVP calculations."
+        ),
+        docs_url=DOCS_URL,
+        table_path=DATA_PATH / "grambow_barrier_heights_metrics_table.json",
+        info_path=DATA_PATH / "info.json",
+        extra_components=[
+            Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
+        ],
+    )
+
+
+if __name__ == "__main__":
+    full_app = Dash(
+        __name__,
+        assets_folder=DATA_PATH.parent.parent,
+        suppress_callback_exceptions=True,
+    )
+    benchmark_app = get_app()
+    full_app.layout = benchmark_app.layout
+    benchmark_app.register_callbacks()
+    full_app.run(port=8071, debug=True)

--- a/ml_peg/app/molecular_reactions/grambow_barrier_heights/app_grambow_barrier_heights.py
+++ b/ml_peg/app/molecular_reactions/grambow_barrier_heights/app_grambow_barrier_heights.py
@@ -7,8 +7,8 @@ from dash.html import Div
 
 from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
-from ml_peg.app.utils.build_callbacks import plot_from_table_cell
-from ml_peg.app.utils.load import read_density_plot_for_model
+from ml_peg.app.utils.build_callbacks import plot_from_table_cell, struct_from_scatter
+from ml_peg.app.utils.load import collect_traj_assets, read_density_plot_for_model
 from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
 
@@ -39,6 +39,21 @@ class GrambowBarrierHeightsApp(BaseApp):
             cell_to_plot=density_plots,
         )
 
+        struct_trajs = collect_traj_assets(
+            data_path=DATA_PATH,
+            assets_prefix="/assets/molecular_reactions/grambow_barrier_heights",
+            models=MODELS,
+            traj_dirname="density_traj",
+            suffix=".extxyz",
+        )
+        for model in struct_trajs:
+            struct_from_scatter(
+                scatter_id=f"{BENCHMARK_NAME}-{model}-barrier-figure",
+                struct_id=f"{BENCHMARK_NAME}-struct-placeholder",
+                structs=struct_trajs[model],
+                mode="traj",
+            )
+
 
 def get_app() -> GrambowBarrierHeightsApp:
     """
@@ -62,6 +77,7 @@ def get_app() -> GrambowBarrierHeightsApp:
         info_path=DATA_PATH / "info.json",
         extra_components=[
             Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
+            Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
         ],
     )
 

--- a/ml_peg/calcs/molecular_reactions/grambow_barrier_heights/calc_grambow_barrier_heights.py
+++ b/ml_peg/calcs/molecular_reactions/grambow_barrier_heights/calc_grambow_barrier_heights.py
@@ -1,0 +1,70 @@
+"""
+Compute the Grambow reaction barrier dataset.
+
+Grambow, C.A., Pattanaik, L. & Green, W.H.
+Reactants, products, and transition states of elementary chemical reactions
+based on quantum chemistry.
+Sci Data 7, 137 (2020).
+DOI: 10.1038/s41597-020-0460-4
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from warnings import warn
+
+from mlipaudit.benchmarks.reactivity.reactivity import ReactivityModelOutput
+import pytest
+
+from ml_peg.calcs.utils.mlipaudit import MlPegGrambowBarrierHeightsBenchmark
+from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_models
+
+MODELS = load_models(current_models)
+
+OUT_PATH = Path(__file__).parent / "outputs"
+
+
+@pytest.mark.parametrize("mlip", MODELS.items())
+def test_grambow_barrier_heights(mlip: tuple[str, Any]) -> None:
+    """
+    Benchmark the Grambow reaction barrier dataset.
+
+    Parameters
+    ----------
+    mlip
+        Name of model and model object to get calculator.
+    """
+    model_name, model = mlip
+    calc = model.get_calculator(precision="high")
+    calc = model.add_d3_calculator(calc)
+
+    data_input_dir = download_s3_data(
+        key="inputs/molecular_reactions/grambow_barrier_heights/grambow_barrier_heights.zip",
+        filename="grambow_barrier_heights.zip",
+    )
+
+    out_path = OUT_PATH / model_name
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    benchmark = MlPegGrambowBarrierHeightsBenchmark(
+        force_field=calc,
+        data_input_dir=data_input_dir,
+        run_mode="standard",
+    )
+    try:
+        benchmark.run_model()
+    except Exception as exc:
+        warn(
+            f"Error running Grambow barrier heights benchmark for {model_name}: {exc}",
+            stacklevel=2,
+        )
+        benchmark.model_output = ReactivityModelOutput(
+            reaction_ids=[], energy_predictions=[]
+        )
+
+    (out_path / "model_output.json").write_text(
+        benchmark.model_output.model_dump_json()
+    )

--- a/ml_peg/calcs/molecular_reactions/grambow_barrier_heights/calc_grambow_barrier_heights.py
+++ b/ml_peg/calcs/molecular_reactions/grambow_barrier_heights/calc_grambow_barrier_heights.py
@@ -59,13 +59,13 @@ def test_grambow_barrier_heights(mlip: tuple[str, Any]) -> None:
     dataset_dir = OUT_PATH / benchmark_name
     dataset_dir.mkdir(parents=True, exist_ok=True)
     shutil.copy(
-        data_input_dir / benchmark_name / GRAMBOW_DATASET_FILENAME,
+        data_input_dir / "grambow_barrier_heights" / GRAMBOW_DATASET_FILENAME,
         dataset_dir,
     )
 
     benchmark = MlPegGrambowBarrierHeightsBenchmark(
         force_field=calc,
-        data_input_dir=data_input_dir,
+        data_input_dir=OUT_PATH,
         run_mode="standard",
     )
     try:

--- a/ml_peg/calcs/molecular_reactions/grambow_barrier_heights/calc_grambow_barrier_heights.py
+++ b/ml_peg/calcs/molecular_reactions/grambow_barrier_heights/calc_grambow_barrier_heights.py
@@ -11,11 +11,17 @@ DOI: 10.1038/s41597-020-0460-4
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 from typing import Any
 from warnings import warn
 
-from mlipaudit.benchmarks.reactivity.reactivity import ReactivityModelOutput
 import pytest
+
+pytest.importorskip("mlipaudit", reason="Please install `mlipaudit` extra")
+from mlipaudit.benchmarks.reactivity.reactivity import (
+    GRAMBOW_DATASET_FILENAME,
+    ReactivityModelOutput,
+)
 
 from ml_peg.calcs.utils.mlipaudit import MlPegGrambowBarrierHeightsBenchmark
 from ml_peg.calcs.utils.utils import download_s3_data
@@ -48,6 +54,14 @@ def test_grambow_barrier_heights(mlip: tuple[str, Any]) -> None:
 
     out_path = OUT_PATH / model_name
     out_path.mkdir(parents=True, exist_ok=True)
+
+    benchmark_name = MlPegGrambowBarrierHeightsBenchmark.name
+    dataset_dir = OUT_PATH / benchmark_name
+    dataset_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(
+        data_input_dir / benchmark_name / GRAMBOW_DATASET_FILENAME,
+        dataset_dir,
+    )
 
     benchmark = MlPegGrambowBarrierHeightsBenchmark(
         force_field=calc,

--- a/ml_peg/calcs/utils/mlipaudit.py
+++ b/ml_peg/calcs/utils/mlipaudit.py
@@ -5,11 +5,23 @@ from __future__ import annotations
 from mlipaudit.benchmarks.conformer_selection.conformer_selection import (
     ConformerSelectionBenchmark,
 )
+from mlipaudit.benchmarks.reactivity.reactivity import ReactivityBenchmark
 
 
 class MlPegConformerSelectionBenchmark(ConformerSelectionBenchmark):
     """
     ConformerSelectionBenchmark wired up for ml-peg's ASE calculators.
+
+    ``skip_if_elements_missing`` is disabled because ASE ``Calculator`` objects
+    do not expose ``allowed_atomic_numbers``.
+    """
+
+    skip_if_elements_missing = False
+
+
+class MlPegGrambowBarrierHeightsBenchmark(ReactivityBenchmark):
+    """
+    ReactivityBenchmark wired up for ml-peg's ASE calculators.
 
     ``skip_if_elements_missing`` is disabled because ASE ``Calculator`` objects
     do not expose ``allowed_atomic_numbers``.


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to a "new benchmark" issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

The Grambow dataset of reaction comprises about 12,000 reactant/product/transition state triplets for reactions of small neutral organic molecules limited to the elements H, C, N and O, accompanied by energy labels at ωB97X-D3/def2-TZVP level of theory. This benchmark assesses if the MLIP can accurately predict the barrier heights of all reactions across the full dataset. Reaction energies are also reported, however the benchmark is specifically targeted at barrier heights.

## Linked issue

<!-- Enter the number of the issue this resolves. This should be labelled as "new benchmark". -->
Resolves #662 

## Progress

<!-- Which aspects of adding the new benchmark are complete? Any issues encountered can also be discussed here. -->
- [x] Calculations
- [x] Analysis
- [x] Application
- [x] Documentation

## Testing

<!-- Which models have you tested your benchmark on? -->

## New decorators/callbacks

<!-- Are new callbacks required for the interactivity you need? -->
