### PR TITLE
mark water slab dipoles test as very slow

### DIFF
--- a/ml_peg/calcs/physicality/water_slab_dipoles/calc_water_slab_dipoles.py
+++ b/ml_peg/calcs/physicality/water_slab_dipoles/calc_water_slab_dipoles.py
@@ -26,6 +26,7 @@ OUT_PATH = Path(__file__).parent / "outputs"
 EV_TO_KJ_PER_MOL = units.mol / units.kJ
 
 
+@pytest.mark.very_slow
 @pytest.mark.parametrize("mlip", MODELS.items())
 def test_water_dipole(mlip: tuple[str, Any]) -> None:
     """


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Currently, the water slab dipoles test is not marked as very slow, so that they run even when --no-run-slow is enabled.
This fixes it.


## Testing
I verified tests were skipped correctly now.