### PR TITLE
Fix BH2O-36 energy units, change metrics

### DIFF
--- a/ml_peg/analysis/molecular_reactions/BH2O_36/analyse_BH2O_36.py
+++ b/ml_peg/analysis/molecular_reactions/BH2O_36/analyse_BH2O_36.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ase import units
 from ase.io import read, write
 import pytest
 
@@ -52,8 +53,8 @@ SYSTEM_NAMES = [name.replace("_ts", "") for name in INFO["filenames"]]
 @plot_parity(
     filename=OUT_PATH / "figure_bh2o_36_barriers.json",
     title="Reaction barriers",
-    x_label="Predicted barrier / eV",
-    y_label="Reference barrier / eV",
+    x_label="Predicted barrier / kcal/mol",
+    y_label="Reference barrier / kcal/mol",
     hoverdata={
         "System": [n for n in SYSTEM_NAMES for _ in range(2)],
         "Barrier Type": [
@@ -84,19 +85,27 @@ def barrier_heights() -> dict[str, list]:
 
             # TS - Reactants barrier
             results[model_name].append(
-                atoms_ts.info["pred_energy"] - atoms_rct.info["pred_energy"]
+                (atoms_ts.info["pred_energy"] - atoms_rct.info["pred_energy"])
+                * units.mol
+                / units.kcal
             )
             # TS - Products barrier
             results[model_name].append(
-                atoms_ts.info["pred_energy"] - atoms_pro.info["pred_energy"]
+                (atoms_ts.info["pred_energy"] - atoms_pro.info["pred_energy"])
+                * units.mol
+                / units.kcal
             )
 
             if not ref_stored:
                 results["ref"].append(
-                    atoms_ts.info["ref_energy"] - atoms_rct.info["ref_energy"]
+                    (atoms_ts.info["ref_energy"] - atoms_rct.info["ref_energy"])
+                    * units.mol
+                    / units.kcal
                 )
                 results["ref"].append(
-                    atoms_ts.info["ref_energy"] - atoms_pro.info["ref_energy"]
+                    (atoms_ts.info["ref_energy"] - atoms_pro.info["ref_energy"])
+                    * units.mol
+                    / units.kcal
                 )
 
             # Write structures for app

--- a/ml_peg/analysis/molecular_reactions/BH2O_36/metrics.yml
+++ b/ml_peg/analysis/molecular_reactions/BH2O_36/metrics.yml
@@ -1,7 +1,7 @@
 metrics:
   MAE:
-    good: 0.0
-    bad: 2.0
-    unit: eV
+    good: 0.7
+    bad: 20.0
+    unit: kcal/mol
     tooltip: Mean Absolute Error for all systems
     level_of_theory: CCSD(T)

--- a/ml_peg/calcs/molecular_reactions/BH2O_36/calc_BH2O_36.py
+++ b/ml_peg/calcs/molecular_reactions/BH2O_36/calc_BH2O_36.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any
 from warnings import warn
 
+from ase import units
 from ase.io import read, write
 import numpy as np
 import pytest
@@ -106,7 +107,7 @@ def test_bh2o_36(mlip: tuple[str, Any]) -> None:
         atoms_rct = read(system["rct"]["xyz_path"])
         atoms_rct.info["charge"] = int(system["rct"]["charge"])
         atoms_rct.info["spin"] = 1
-        atoms_rct.info["ref_energy"] = system["rct"]["energy"]
+        atoms_rct.info["ref_energy"] = system["rct"]["energy"] * units.Hartree
         atoms_rct.calc = calc
         try:
             atoms_rct.info["pred_energy"] = atoms_rct.get_potential_energy()
@@ -120,7 +121,7 @@ def test_bh2o_36(mlip: tuple[str, Any]) -> None:
         atoms_pro = read(system["pro"]["xyz_path"])
         atoms_pro.info["charge"] = int(system["pro"]["charge"])
         atoms_pro.info["spin"] = 1
-        atoms_pro.info["ref_energy"] = system["pro"]["energy"]
+        atoms_pro.info["ref_energy"] = system["pro"]["energy"] * units.Hartree
         atoms_pro.calc = calc
         try:
             atoms_pro.info["pred_energy"] = atoms_pro.get_potential_energy()
@@ -134,7 +135,7 @@ def test_bh2o_36(mlip: tuple[str, Any]) -> None:
         atoms_ts = read(system["ts"]["xyz_path"])
         atoms_ts.info["charge"] = int(system["ts"]["charge"])
         atoms_ts.info["spin"] = 1
-        atoms_ts.info["ref_energy"] = system["ts"]["energy"]
+        atoms_ts.info["ref_energy"] = system["ts"]["energy"] * units.Hartree
         atoms_ts.calc = calc
         try:
             atoms_ts.info["pred_energy"] = atoms_ts.get_potential_energy()


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

<!-- Describe your proposed changes. This can be brief, as most information can be in the linked issue. -->

Errors were nonsensical because the reference energies were in Hartree and predicted energies in eV. Changed reference energies to eV in calc script. Changed all energies to kcal/mol in analysis and modified thresholds to 0.7 kcal/mol (MAE of wB97M-V vs CCSD) and 20 kcal/mol.

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #

## Testing

<!-- How have your proposed changes been tested? -->
