### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+## 2024-05-24 - [Replace pandas iterrows for performance]
+**Learning:** Pandas `iterrows()` is known as a significant performance bottleneck due to returning Series objects and type coercion per row. Using `.itertuples(index=False, name=None)` for standard iteration or `.to_dict('records')` when dictionary access for dynamic columns is needed provides massive speedups for iterating through records.
+**Action:** Always prefer `itertuples` or `to_dict('records')` over `iterrows` in Pandas when building benchmarks or evaluating row-wise logic.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -301,7 +301,8 @@ def run_elasticity_benchmark(
         else {}
     )
     atoms_list = []
-    for _, row in results.iterrows():
+    # ⚡ Bolt: Use to_dict('records') over iterrows for faster iteration.
+    for row in results.to_dict("records"):
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             struct = mock_ref_map.get(row[benchmark.index_name])

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    # ⚡ Bolt: Replace slow iterrows() with fast itertuples().
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,10 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    # ⚡ Bolt: Replace slow iterrows() with fast itertuples().
+    for row in df.itertuples(index=False, name=None):
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,7 +106,8 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        # ⚡ Bolt: Use to_dict('records') over iterrows for faster iteration.
+        for row in tqdm(df_refs.to_dict("records"), dataset, total=df_refs.shape[0]):
             atoms_list = []
             identifier = row["Reaction"]
             reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.


### PR DESCRIPTION
💡 What: Replaced slow `df.iterrows()` calls with `df.to_dict("records")` or `df.itertuples(index=False, name=None)` throughout calculation scripts.
🎯 Why: `iterrows()` is a known pandas performance bottleneck as it creates a Series for every row. Switching to dicts/tuples speeds up row processing, especially in large benchmarks like GSCDB138 and elasticity.
📊 Impact: Faster iteration loops resulting in reduced overhead for benchmark data parsing and preparation.
🔬 Measurement: Run the affected calculation scripts or tests to confirm that structure loading and reference energy parsing continue to work, while avoiding the overhead of `iterrows()`.

---
*PR created automatically by Jules for task [5743654104615482795](https://jules.google.com/task/5743654104615482795) started by @alinelena*