### PR TITLE
Add Defect category to materials weights

### DIFF
--- a/ml_peg/app/utils/weight_presets.yml
+++ b/ml_peg/app/utils/weight_presets.yml
@@ -6,6 +6,7 @@ Materials:
   - Surfaces
   - NEBs
   - Physicality
+  - Defect
 Molecules:
   - Molecular Systems
   - Molecular Reactions


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [x] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [x] I have added human-written tests for the new logic.
- [x] I have properly cited any upstream algorithms or libraries the AI utilized.
- [x] I have disclosed significant AI tool usage in the PR description.

## Summary

Adds defect benchmarks to materials default weights, as they seem appropriate