### PR TITLE
Add Matbench Discovery framework attribution

### DIFF
--- a/ml_peg/app/utils/frameworks.yml
+++ b/ml_peg/app/utils/frameworks.yml
@@ -16,7 +16,7 @@ matbench-discovery:
   color: "#061e25"
   text_color: "#ffffff"
   url: "https://matbench-discovery.materialsproject.org"
-  logo: "https://raw.githubusercontent.com/janosh/matbench-discovery/main/site/static/favicon.svg"
+  logo: "https://matbench-discovery.materialsproject.org/favicon.svg"
   tooltip: "Benchmarks adapted from the Matbench Discovery framework"
 
 mace-multihead:

--- a/ml_peg/app/utils/frameworks.yml
+++ b/ml_peg/app/utils/frameworks.yml
@@ -11,6 +11,14 @@ mlip_arena:
   url: "https://huggingface.co/spaces/atomind/mlip-arena"
   logo: "https://huggingface.co/front/assets/huggingface_logo-noborder.svg"
 
+matbench-discovery:
+  label: Matbench Discovery
+  color: "#061e25"
+  text_color: "#ffffff"
+  url: "https://matbench-discovery.materialsproject.org"
+  logo: "https://raw.githubusercontent.com/janosh/matbench-discovery/main/site/static/favicon.svg"
+  tooltip: "Benchmarks adapted from the Matbench Discovery framework"
+
 mace-multihead:
   label: Multihead Cross Learning
   color: "#7c3aed"

--- a/ml_peg/app/utils/frameworks.yml
+++ b/ml_peg/app/utils/frameworks.yml
@@ -17,7 +17,11 @@ matbench-discovery:
   text_color: "#ffffff"
   url: "https://matbench-discovery.materialsproject.org"
   logo: "https://matbench-discovery.materialsproject.org/favicon.svg"
-  tooltip: "Benchmarks adapted from the Matbench Discovery framework"
+  tooltip: "Benchmarks adapted from Matbench Discovery"
+  description: "Matbench Discovery evaluates machine-learned interatomic potentials for materials discovery, relaxed crystal structures, and diatomic interactions. ML-PEG runs the contributed benchmarks on its own model selection."
+  project_url: "https://matbench-discovery.materialsproject.org"
+  paper_url: "https://doi.org/10.1038/s42256-025-01055-1"
+  github: "https://github.com/janosh/matbench-discovery"
 
 mace-multihead:
   label: Multihead Cross Learning


### PR DESCRIPTION
## Summary
- register Matbench Discovery in the framework badge registry
- link attribution to the project homepage and production favicon
- provide colors and tooltip text for framework views

Validated with `get_framework_config("matbench-discovery")`; the homepage and SVG logo both return HTTP 200.