### PR TITLE
feat: add solvent radial distribution benchmark

### DIFF
--- a/docs/source/user_guide/benchmarks/molecular_dynamics.rst
+++ b/docs/source/user_guide/benchmarks/molecular_dynamics.rst
@@ -116,3 +116,45 @@ Packmol generated
 Reference data:
 * M. Southard and D. Green, Perry’s Chemical Engineers’ Handbook, 9th Edition. McGraw-Hill Education, 2018.
 * Experimental
+
+
+Solvent radial distribution
+===========================
+
+Summary
+-------
+
+Performance in reproducing the radial distribution functions of common molecular
+liquids. For each of carbon tetrachloride, methanol and acetonitrile, a short NVT
+molecular dynamics simulation is run at 295.15 K starting from an equilibrated box, and
+the radial distribution function of the characteristic atom (C-C for carbon tetrachloride,
+O-O for methanol and N-N for acetonitrile) is computed from the trajectory.
+
+Metrics
+-------
+
+1. Peak deviation
+
+The position of the first solvent peak in the radial distribution function is compared to
+the experimental reference peak position for each solvent, and the absolute deviation is
+averaged across the solvents. A lower deviation is better.
+
+A line plot shows the radial distribution function profiles for each model and solvent.
+
+Computational cost
+------------------
+
+High: one MD simulation per solvent. Faster inference can be achieved using the
+jax-accelerated simulations in MLIP Audit directly.
+
+Data availability
+-----------------
+
+Input structures:
+
+* MLIP Audit benchmark suite, InstaDeep. Equilibrated solvent boxes for carbon
+  tetrachloride, methanol and acetonitrile.
+
+Reference data:
+
+* Experimental first solvent peak positions.

--- a/ml_peg/analysis/molecular_dynamics/solvent_radial_distribution/analyse_solvent_radial_distribution.py
+++ b/ml_peg/analysis/molecular_dynamics/solvent_radial_distribution/analyse_solvent_radial_distribution.py
@@ -1,0 +1,199 @@
+"""Analyse the solvent radial distribution benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ase.calculators.calculator import Calculator
+from mlipaudit.io import load_model_output_from_disk
+import pytest
+
+from ml_peg.analysis.utils.decorators import build_table, plot_scatter
+from ml_peg.analysis.utils.utils import (
+    build_dispersion_name_map,
+    load_metrics_config,
+    write_struct_info,
+)
+from ml_peg.app import APP_ROOT
+from ml_peg.calcs import CALCS_ROOT
+from ml_peg.calcs.utils.mlipaudit import MlPegSolventRadialDistributionBenchmark
+from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_models
+
+MODELS = load_models(current_models)
+DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)
+
+BENCHMARK = MlPegSolventRadialDistributionBenchmark.name
+SOLVENTS = ["CCl4", "methanol", "acetonitrile"]
+
+CALC_PATH = (
+    CALCS_ROOT / "molecular_dynamics" / "solvent_radial_distribution" / "outputs"
+)
+OUT_PATH = APP_ROOT / "data" / "molecular_dynamics" / "solvent_radial_distribution"
+
+METRICS_CONFIG_PATH = Path(__file__).with_name("metrics.yml")
+DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
+    METRICS_CONFIG_PATH
+)
+
+
+def _data_input_dir() -> Path:
+    """
+    Download and return the benchmark input data directory.
+
+    Returns
+    -------
+    Path
+        Directory containing the extracted solvent RDF input data.
+    """
+    return download_s3_data(
+        key="inputs/molecular_dynamics/solvent_radial_distribution/solvent_radial_distribution.zip",
+        filename="solvent_radial_distribution.zip",
+    )
+
+
+@pytest.fixture
+def analyze_results() -> dict:
+    """
+    Run the mlipaudit analysis for each model.
+
+    Returns
+    -------
+    dict
+        Mapping of model name to its ``SolventRadialDistributionResult``.
+    """
+    data_input_dir = _data_input_dir()
+
+    results = {}
+    for model_name in MODELS:
+        output_dir = CALC_PATH / model_name / BENCHMARK
+        if not (output_dir / "model_output.zip").exists():
+            continue
+        benchmark = MlPegSolventRadialDistributionBenchmark(
+            force_field=Calculator(),
+            data_input_dir=data_input_dir,
+            run_mode="standard",
+        )
+        benchmark.model_output = load_model_output_from_disk(
+            CALC_PATH / model_name, MlPegSolventRadialDistributionBenchmark
+        )
+        results[model_name] = benchmark.analyze()
+    return results
+
+
+@pytest.fixture
+def struct_info() -> None:
+    """Write the combined element set to ``info.json`` for filtering."""
+    data_input_dir = _data_input_dir()
+    write_struct_info(
+        data_path=[
+            data_input_dir / BENCHMARK / f"{solvent}_eq.pdb" for solvent in SOLVENTS
+        ],
+        out_path=OUT_PATH,
+    )
+
+
+@pytest.fixture
+@plot_scatter(
+    title="Solvent radial distribution functions",
+    x_label="r / Å",
+    y_label="g(r)",
+    show_line=True,
+    show_markers=False,
+    filename=str(OUT_PATH / "figure_rdf.json"),
+)
+def rdf_profiles(analyze_results) -> dict[str, tuple[list, list]]:
+    """
+    Get the predicted radial distribution profiles for each solvent.
+
+    Parameters
+    ----------
+    analyze_results
+        Mapping of model name to its ``SolventRadialDistributionResult``.
+
+    Returns
+    -------
+    dict[str, tuple[list, list]]
+        Per-model and per-solvent ``(radii, g(r))`` profiles.
+    """
+    results = {}
+    for model_name, result in analyze_results.items():
+        if result.failed:
+            continue
+        for structure in result.structures:
+            if structure.failed or structure.radii is None or structure.rdf is None:
+                continue
+            results[f"{model_name} ({structure.structure_name})"] = (
+                structure.radii,
+                structure.rdf,
+            )
+    return results
+
+
+@pytest.fixture
+def get_peak_deviation(analyze_results) -> dict[str, float]:
+    """
+    Get the average first solvent peak deviation for each model.
+
+    Parameters
+    ----------
+    analyze_results
+        Mapping of model name to its ``SolventRadialDistributionResult``.
+
+    Returns
+    -------
+    dict[str, float]
+        Average deviation of the first solvent peak from the reference, in Angstrom.
+    """
+    return {
+        model_name: result.avg_peak_deviation
+        for model_name, result in analyze_results.items()
+    }
+
+
+@pytest.fixture
+@build_table(
+    filename=OUT_PATH / "solvent_radial_distribution_metrics_table.json",
+    metric_tooltips=DEFAULT_TOOLTIPS,
+    thresholds=DEFAULT_THRESHOLDS,
+    weights=DEFAULT_WEIGHTS,
+    mlip_name_map=DISPERSION_NAME_MAP,
+)
+def metrics(
+    rdf_profiles,
+    get_peak_deviation: dict[str, float],
+) -> dict[str, dict]:
+    """
+    Get all metrics.
+
+    Parameters
+    ----------
+    rdf_profiles
+        Predicted RDF profiles for all models (triggers the RDF plot).
+    get_peak_deviation
+        Average first solvent peak deviations for all models.
+
+    Returns
+    -------
+    dict[str, dict]
+        Metric names and values for all models.
+    """
+    return {
+        "Peak Deviation": get_peak_deviation,
+    }
+
+
+def test_solvent_radial_distribution(
+    metrics: dict[str, dict], struct_info: None
+) -> None:
+    """
+    Run solvent radial distribution analysis.
+
+    Parameters
+    ----------
+    metrics : dict[str, dict]
+        Solvent RDF metric results provided by fixtures.
+    struct_info : None
+        Element info written to ``info.json`` for filtering.
+    """

--- a/ml_peg/analysis/molecular_dynamics/solvent_radial_distribution/analyse_solvent_radial_distribution.py
+++ b/ml_peg/analysis/molecular_dynamics/solvent_radial_distribution/analyse_solvent_radial_distribution.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from ase.calculators.calculator import Calculator
+from ase.io import read
+import numpy as np
 import pytest
 
 pytest.importorskip("mlipaudit", reason="Please install `mlipaudit` extra")
@@ -14,12 +17,10 @@ from ml_peg.analysis.utils.decorators import build_table, plot_scatter
 from ml_peg.analysis.utils.utils import (
     build_dispersion_name_map,
     load_metrics_config,
-    write_struct_info,
 )
 from ml_peg.app import APP_ROOT
 from ml_peg.calcs import CALCS_ROOT
 from ml_peg.calcs.utils.mlipaudit import MlPegSolventRadialDistributionBenchmark
-from ml_peg.calcs.utils.utils import download_s3_data
 from ml_peg.models import current_models
 from ml_peg.models.get_models import load_models
 
@@ -40,19 +41,40 @@ DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
 )
 
 
-def _data_input_dir() -> Path:
+def solvent_pdb(solvent: str) -> Path:
     """
-    Download and return the benchmark input data directory.
+    Get the path to a solvent's equilibrated structure saved by the calculation.
+
+    Parameters
+    ----------
+    solvent
+        Name of the solvent.
 
     Returns
     -------
     Path
-        Directory containing the extracted solvent RDF input data.
+        Path to the solvent's equilibrated PDB file.
     """
-    return download_s3_data(
-        key="inputs/molecular_dynamics/solvent_radial_distribution/solvent_radial_distribution.zip",
-        filename="solvent_radial_distribution.zip",
-    )
+    return CALC_PATH / BENCHMARK / f"{solvent}_eq.pdb"
+
+
+def check_dataset() -> None:
+    """
+    Check the input structures saved by the calculation are available.
+
+    The calculation copies the downloaded input data into its outputs, so the
+    analysis does not need to download it again.
+
+    Raises
+    ------
+    ValueError
+        If any solvent structure is missing from the calculation outputs.
+    """
+    for solvent in SOLVENTS:
+        if not solvent_pdb(solvent).exists():
+            raise ValueError(
+                f"{solvent_pdb(solvent)} does not exist. Please run the calculation."
+            )
 
 
 @pytest.fixture
@@ -65,7 +87,7 @@ def analyze_results() -> dict:
     dict
         Mapping of model name to its ``SolventRadialDistributionResult``.
     """
-    data_input_dir = _data_input_dir()
+    check_dataset()
 
     results = {}
     for model_name in MODELS:
@@ -74,7 +96,7 @@ def analyze_results() -> dict:
             continue
         benchmark = MlPegSolventRadialDistributionBenchmark(
             force_field=Calculator(),
-            data_input_dir=data_input_dir,
+            data_input_dir=CALC_PATH,
             run_mode="standard",
         )
         benchmark.model_output = load_model_output_from_disk(
@@ -85,15 +107,33 @@ def analyze_results() -> dict:
 
 
 @pytest.fixture
-def struct_info() -> None:
-    """Write the combined element set to ``info.json`` for filtering."""
-    data_input_dir = _data_input_dir()
-    write_struct_info(
-        data_path=[
-            data_input_dir / BENCHMARK / f"{solvent}_eq.pdb" for solvent in SOLVENTS
+def struct_info() -> dict:
+    """
+    Write per-solvent element info to ``info.json`` for filtering.
+
+    Elements are stored as one list per solvent, so individual solvents can be
+    excluded once partial filtering is supported. The order follows ``SOLVENTS``.
+
+    Returns
+    -------
+    dict
+        Mapping with the per-solvent lists of elements.
+    """
+    check_dataset()
+
+    info = {
+        "systems": list(SOLVENTS),
+        "elements": [
+            sorted(set(read(solvent_pdb(solvent)).get_chemical_symbols()))
+            for solvent in SOLVENTS
         ],
-        out_path=OUT_PATH,
-    )
+    }
+
+    OUT_PATH.mkdir(parents=True, exist_ok=True)
+    with (OUT_PATH / "info.json").open("w", encoding="utf-8") as f:
+        json.dump(info, f, indent=1)
+
+    return info
 
 
 @pytest.fixture
@@ -149,7 +189,11 @@ def get_peak_deviation(analyze_results) -> dict[str, float]:
         Average deviation of the first solvent peak from the reference, in Angstrom.
     """
     return {
-        model_name: result.avg_peak_deviation
+        model_name: (
+            result.avg_peak_deviation
+            if result.avg_peak_deviation is not None
+            else np.nan
+        )
         for model_name, result in analyze_results.items()
     }
 
@@ -187,7 +231,7 @@ def metrics(
 
 
 def test_solvent_radial_distribution(
-    metrics: dict[str, dict], struct_info: None
+    metrics: dict[str, dict], struct_info: dict
 ) -> None:
     """
     Run solvent radial distribution analysis.
@@ -196,6 +240,6 @@ def test_solvent_radial_distribution(
     ----------
     metrics : dict[str, dict]
         Solvent RDF metric results provided by fixtures.
-    struct_info : None
+    struct_info : dict
         Element info written to ``info.json`` for filtering.
     """

--- a/ml_peg/analysis/molecular_dynamics/solvent_radial_distribution/analyse_solvent_radial_distribution.py
+++ b/ml_peg/analysis/molecular_dynamics/solvent_radial_distribution/analyse_solvent_radial_distribution.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from ase.calculators.calculator import Calculator
-from mlipaudit.io import load_model_output_from_disk
 import pytest
+
+pytest.importorskip("mlipaudit", reason="Please install `mlipaudit` extra")
+from mlipaudit.io import load_model_output_from_disk
 
 from ml_peg.analysis.utils.decorators import build_table, plot_scatter
 from ml_peg.analysis.utils.utils import (

--- a/ml_peg/analysis/molecular_dynamics/solvent_radial_distribution/metrics.yml
+++ b/ml_peg/analysis/molecular_dynamics/solvent_radial_distribution/metrics.yml
@@ -1,0 +1,8 @@
+metrics:
+  Peak Deviation:
+    good: 0.0
+    bad: 0.5
+    unit: Å
+    weight: 1
+    tooltip: Deviation of the first solvent peak position from the experimental reference, averaged across the solvents.
+    level_of_theory: Experiment

--- a/ml_peg/app/molecular_dynamics/solvent_radial_distribution/app_solvent_radial_distribution.py
+++ b/ml_peg/app/molecular_dynamics/solvent_radial_distribution/app_solvent_radial_distribution.py
@@ -1,0 +1,66 @@
+"""Run solvent radial distribution benchmark app."""
+
+from __future__ import annotations
+
+from dash import Dash
+from dash.html import Div
+
+from ml_peg.app import APP_ROOT
+from ml_peg.app.base_app import BaseApp
+from ml_peg.app.utils.build_callbacks import plot_from_table_column
+from ml_peg.app.utils.load import read_plot
+
+BENCHMARK_NAME = "SolventRDF"
+DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/molecular_dynamics.html#solvent-radial-distribution"
+DATA_PATH = APP_ROOT / "data" / "molecular_dynamics" / "solvent_radial_distribution"
+
+
+class SolventRDFApp(BaseApp):
+    """Solvent radial distribution benchmark app layout and callbacks."""
+
+    def register_callbacks(self) -> None:
+        """Register callbacks to app."""
+        scatter = read_plot(
+            DATA_PATH / "figure_rdf.json",
+            id=f"{BENCHMARK_NAME}-figure",
+        )
+
+        plot_from_table_column(
+            table_id=self.table_id,
+            plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
+            column_to_plot={"Peak Deviation": scatter},
+        )
+
+
+def get_app() -> SolventRDFApp:
+    """
+    Get solvent radial distribution benchmark app layout and callback registration.
+
+    Returns
+    -------
+    SolventRDFApp
+        Benchmark layout and callback registration.
+    """
+    return SolventRDFApp(
+        name="Solvent RDF",
+        framework_ids="mlip_audit",
+        description=(
+            "Performance in reproducing the radial distribution functions of "
+            "liquid carbon tetrachloride, methanol and acetonitrile from short "
+            "NVT molecular dynamics simulations. Reference data from experiment."
+        ),
+        docs_url=DOCS_URL,
+        table_path=DATA_PATH / "solvent_radial_distribution_metrics_table.json",
+        info_path=DATA_PATH / "info.json",
+        extra_components=[
+            Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
+        ],
+    )
+
+
+if __name__ == "__main__":
+    full_app = Dash(__name__, assets_folder=DATA_PATH.parent.parent)
+    benchmark_app = get_app()
+    full_app.layout = benchmark_app.layout
+    benchmark_app.register_callbacks()
+    full_app.run(port=8070, debug=True)

--- a/ml_peg/calcs/molecular_dynamics/solvent_radial_distribution/calc_solvent_radial_distribution.py
+++ b/ml_peg/calcs/molecular_dynamics/solvent_radial_distribution/calc_solvent_radial_distribution.py
@@ -1,0 +1,69 @@
+"""
+Compute solvent radial distribution functions from molecular dynamics.
+
+A short NVT molecular dynamics simulation is run for a box of each solvent
+(carbon tetrachloride, methanol and acetonitrile), and the radial distribution
+function of the atom of interest is compared to experiment.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from warnings import warn
+
+from mlipaudit.benchmarks.solvent_radial_distribution.solvent_radial_distribution import (  # noqa: E501
+    SolventRadialDistributionModelOutput,
+)
+from mlipaudit.io import write_model_output_to_disk
+import pytest
+
+from ml_peg.calcs.utils.mlipaudit import MlPegSolventRadialDistributionBenchmark
+from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_models
+
+MODELS = load_models(current_models)
+
+OUT_PATH = Path(__file__).parent / "outputs"
+
+
+@pytest.mark.parametrize("mlip", MODELS.items())
+def test_solvent_radial_distribution(mlip: tuple[str, Any]) -> None:
+    """
+    Benchmark the solvent radial distribution functions.
+
+    Parameters
+    ----------
+    mlip
+        Name of model and model object to get calculator.
+    """
+    model_name, model = mlip
+    calc = model.get_calculator()
+    calc = model.add_d3_calculator(calc)
+
+    data_input_dir = download_s3_data(
+        key="inputs/molecular_dynamics/solvent_radial_distribution/solvent_radial_distribution.zip",
+        filename="solvent_radial_distribution.zip",
+    )
+
+    benchmark = MlPegSolventRadialDistributionBenchmark(
+        force_field=calc,
+        data_input_dir=data_input_dir,
+        run_mode="standard",
+    )
+    try:
+        benchmark.run_model()
+    except Exception as exc:
+        warn(
+            f"Error running solvent RDF benchmark for {model_name}: {exc}",
+            stacklevel=2,
+        )
+        # Empty structure lists are treated as a failed benchmark by analyze().
+        benchmark.model_output = SolventRadialDistributionModelOutput(
+            structure_names=[], simulation_states=[]
+        )
+
+    write_model_output_to_disk(
+        "solvent_radial_distribution", benchmark.model_output, OUT_PATH / model_name
+    )

--- a/ml_peg/calcs/molecular_dynamics/solvent_radial_distribution/calc_solvent_radial_distribution.py
+++ b/ml_peg/calcs/molecular_dynamics/solvent_radial_distribution/calc_solvent_radial_distribution.py
@@ -9,6 +9,7 @@ function of the atom of interest is compared to experiment.
 from __future__ import annotations
 
 from pathlib import Path
+import shutil
 from typing import Any
 from warnings import warn
 
@@ -48,6 +49,11 @@ def test_solvent_radial_distribution(mlip: tuple[str, Any]) -> None:
         key="inputs/molecular_dynamics/solvent_radial_distribution/solvent_radial_distribution.zip",
         filename="solvent_radial_distribution.zip",
     )
+
+    # Save the input data to the calculation outputs so the analysis is self
+    # contained and does not need to download it again.
+    name = MlPegSolventRadialDistributionBenchmark.name
+    shutil.copytree(data_input_dir / name, OUT_PATH / name, dirs_exist_ok=True)
 
     benchmark = MlPegSolventRadialDistributionBenchmark(
         force_field=calc,

--- a/ml_peg/calcs/molecular_dynamics/solvent_radial_distribution/calc_solvent_radial_distribution.py
+++ b/ml_peg/calcs/molecular_dynamics/solvent_radial_distribution/calc_solvent_radial_distribution.py
@@ -12,11 +12,13 @@ from pathlib import Path
 from typing import Any
 from warnings import warn
 
+import pytest
+
+pytest.importorskip("mlipaudit", reason="Please install `mlipaudit` extra")
 from mlipaudit.benchmarks.solvent_radial_distribution.solvent_radial_distribution import (  # noqa: E501
     SolventRadialDistributionModelOutput,
 )
 from mlipaudit.io import write_model_output_to_disk
-import pytest
 
 from ml_peg.calcs.utils.mlipaudit import MlPegSolventRadialDistributionBenchmark
 from ml_peg.calcs.utils.utils import download_s3_data

--- a/ml_peg/calcs/utils/mlipaudit.py
+++ b/ml_peg/calcs/utils/mlipaudit.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from mlipaudit.benchmarks.conformer_selection.conformer_selection import (
+from mlipaudit.benchmarks import (
     ConformerSelectionBenchmark,
-)
-from mlipaudit.benchmarks.solvent_radial_distribution.solvent_radial_distribution import (  # noqa: E501
     SolventRadialDistributionBenchmark,
+    TautomersBenchmark,
 )
-from mlipaudit.benchmarks.tautomers.tautomers import TautomersBenchmark
 
 
 class MlPegConformerSelectionBenchmark(ConformerSelectionBenchmark):

--- a/ml_peg/calcs/utils/mlipaudit.py
+++ b/ml_peg/calcs/utils/mlipaudit.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from mlipaudit.benchmarks.conformer_selection.conformer_selection import (
     ConformerSelectionBenchmark,
 )
+from mlipaudit.benchmarks.solvent_radial_distribution.solvent_radial_distribution import (  # noqa: E501
+    SolventRadialDistributionBenchmark,
+)
 from mlipaudit.benchmarks.tautomers.tautomers import TautomersBenchmark
 
 
@@ -14,6 +17,19 @@ class MlPegConformerSelectionBenchmark(ConformerSelectionBenchmark):
 
     ``skip_if_elements_missing`` is disabled because ASE ``Calculator`` objects
     do not expose ``allowed_atomic_numbers``.
+    """
+
+    skip_if_elements_missing = False
+
+
+class MlPegSolventRadialDistributionBenchmark(SolventRadialDistributionBenchmark):
+    """
+    ``SolventRadialDistributionBenchmark`` wired up for ml-peg's ASE calculators.
+
+    ``skip_if_elements_missing`` is disabled because ml-peg's ASE ``Calculator``
+    objects do not expose the set of elements the underlying model supports, so
+    the benchmark cannot decide up front whether to skip. Missing element errors
+    are instead handled at runtime.
     """
 
     skip_if_elements_missing = False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,6 @@ mlipaudit = [
     "jax<0.11; python_version >= '3.11'",
     "jaxlib<0.11; python_version >= '3.11'",
 ]
-mlipaudit = [
-    "mlipaudit; python_version >= '3.11'",
-]
 orb = [
     "orb-models == 0.6.2; sys_platform != 'win32' and python_version >= '3.12'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,6 +72,9 @@ mlipaudit = [
     "jax<0.11; python_version >= '3.11'",
     "jaxlib<0.11; python_version >= '3.11'",
 ]
+mlipaudit = [
+    "mlipaudit; python_version >= '3.11'",
+]
 orb = [
     "orb-models == 0.6.2; sys_platform != 'win32' and python_version >= '3.12'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ mlipaudit = [
     "jax<0.11; python_version >= '3.11'",
     "jaxlib<0.11; python_version >= '3.11'",
 ]
+mlipaudit = [
+    "mlipaudit; python_version >= '3.11'",
+]
 orb = [
     "orb-models == 0.6.2; sys_platform != 'win32' and python_version >= '3.12'",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ mlipaudit = [
     "jax<0.11; python_version >= '3.11'",
     "jaxlib<0.11; python_version >= '3.11'",
 ]
-mlipaudit = [
-    "mlipaudit; python_version >= '3.11'",
-]
 orb = [
     "orb-models == 0.6.2; sys_platform != 'win32' and python_version >= '3.12'",
 ]


### PR DESCRIPTION
## Pre-review checklist for PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).

## Summary

Migrates the solvent radial distribution benchmark from the MLIP Audit suite. For each of
carbon tetrachloride, methanol and acetonitrile, a short NVT molecular dynamics simulation
is run from an equilibrated box, and the radial distribution function of the characteristic
atom (C-C, O-O and N-N respectively) is computed from the trajectory. The position of the
first solvent peak is compared to the experimental reference peak position and the absolute
deviation is averaged across the solvents. The interactive feature is a line plot of the
RDF profiles for each model and solvent.

This PR also adds the shared `mlipaudit` wiring (optional extra, uv git source, `mlip_audit`
framework badge and the `ml_peg/calcs/utils/mlipaudit.py` calculator adapter). This overlaps
with other in-flight MLIP Audit benchmark PRs (e.g. #666, #660); whichever merges first
introduces the shared wiring, and the others will need a rebase to drop the duplicate.

## Linked issue

Resolves #723

## Progress

- [x] Calculations
- [x] Analysis
- [x] Application
- [x] Documentation

## Testing

The end-to-end run is pending the upload of the input data to S3
(`inputs/molecular_dynamics/solvent_radial_distribution/solvent_radial_distribution.zip`).
All pre-commit hooks (ruff check, ruff format, numpydoc-validation, whitespace/EOF) pass
locally.

## New decorators/callbacks

None. The benchmark reuses the existing `plot_scatter` / `build_table` decorators and the
`plot_from_table_column` callback.
