### PR TITLE
Fix mattersim-5M config and add mattersim-1M

### DIFF
--- a/docs/source/user_guide/models.rst
+++ b/docs/source/user_guide/models.rst
@@ -340,9 +340,25 @@ mattersim-5M
      module: mattersim.forcefield
      class_name: MatterSimCalculator
      device: "cpu"
-     load_path: "mattersim-v1.0.0-5m"
      trained_on_dispersion: false
      level_of_theory: PBE
+     kwargs:
+       load_path: "mattersim-v1.0.0-5m"
+
+mattersim-1M
+------------
+
+
+.. code-block:: yaml
+
+   mattersim-1M:
+     module: mattersim.forcefield
+     class_name: MatterSimCalculator
+     device: "cpu"
+     trained_on_dispersion: false
+     level_of_theory: PBE
+     kwargs:
+       load_path: "mattersim-v1.0.0-1m"
 
 GRACE
 =====

--- a/ml_peg/models/models.yml
+++ b/ml_peg/models/models.yml
@@ -79,9 +79,19 @@ orb-v3-consv-omol:
 #   module: mattersim.forcefield
 #   class_name: MatterSimCalculator
 #   device: "cpu"
-#   load_path: "mattersim-v1.0.0-5m"
 #   trained_on_dispersion: false
 #   level_of_theory: PBE
+#   kwargs:
+#     load_path: "mattersim-v1.0.0-5m"
+
+# mattersim-1M:
+#   module: mattersim.forcefield
+#   class_name: MatterSimCalculator
+#   device: "cpu"
+#   trained_on_dispersion: false
+#   level_of_theory: PBE
+#   kwargs:
+#     load_path: "mattersim-v1.0.0-1m"
 
 # uma-s-1p1-omat:
 #   module: fairchem.core


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [X] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [X] I have added human-written tests for the new logic.
- [X] I have properly cited any upstream algorithms or libraries the AI utilized.
- [X] I have disclosed significant AI tool usage in the PR description.

## Summary

Fixes mattersim-5M's config, which silently loaded the 1M checkpoint instead of 5M due to a YAML structure bug. Also adds a correctly-configured mattersim-1M entry.

## Model Reference

MatterSim: A Deep Learning Atomistic Model Across Elements, Temperatures and Pressures (Yang et al., 2024). https://arxiv.org/abs/2405.04967

## Linked issue

Resolves #736 

## Progress

- [X] Model configuration
- [X] Documentation

## Testing

Ran locality calc/analyse for both models. All tests passed.