### PR TITLE
Add orb-v3-direct-inf-omat model

### DIFF
--- a/docs/source/user_guide/models.rst
+++ b/docs/source/user_guide/models.rst
@@ -211,6 +211,20 @@ orb-v3-consv-inf-omat
      kwargs:
        name: "orb_v3_conservative_inf_omat"
 
+orb-v3-direct-inf-omat
+----------------------
+
+.. code-block:: yaml
+
+   orb-v3-direct-inf-omat:
+     module: orb_models.inference.calculator
+     class_name: OrbCalc
+     device: "cpu"
+     trained_on_dispersion: false
+     level_of_theory: PBE
+     kwargs:
+       name: "orb_v3_direct_inf_omat"
+
 orb-v3-consv-omol
 -----------------
 

--- a/ml_peg/models/models.yml
+++ b/ml_peg/models/models.yml
@@ -66,6 +66,15 @@ orb-v3-consv-inf-omat:
   kwargs:
     name: "orb_v3_conservative_inf_omat"
 
+orb-v3-direct-inf-omat:
+  module: orb_models.inference.calculator
+  class_name: OrbCalc
+  device: "cpu"
+  trained_on_dispersion: false
+  level_of_theory: PBE
+  kwargs:
+    name: "orb_v3_direct_inf_omat"
+
 orb-v3-consv-omol:
   module: orb_models.forcefield.inference.calculator
   class_name: OrbCalc


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to a "new model" issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [X] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [X] I have added human-written tests for the new logic.
- [X] I have properly cited any upstream algorithms or libraries the AI utilized.
- [X] I have disclosed significant AI tool usage in the PR description.

## Summary

ORB-v3 in its direct (non-conservative) configuration, predicting forces directly rather than as the gradient of an energy. Added as a non-conservative control for the physicality benchmarks. 

## Model Reference

orb-models: https://github.com/orbital-materials/orb-models
Checkpoint: orb-v3-direct-inf-omat (https://orbitalmaterials-public-models.s3.us-west-1.amazonaws.com/forcefields/orb-v3/orb-v3-direct-inf-omat-20250404.ckpt)

## Linked issue

Resolves #738 

## Progress

<!-- Which aspects of adding the new model are complete? Any issues encountered can also be discussed here. -->
- [X] Model configuration
- [X] Documentation

## Testing

Loads and runs a force evaluation via ml_peg. Non-conservative behaviour confirmed with the Jacobian Symmetry benchmark (PR #713): lambda ~0.006 vs ~1e-6 for the conservative orb-v3-consv-inf-omat.