### PR TITLE
feat: add inference speed benchmark

### DIFF
--- a/docs/source/user_guide/benchmarks/molecular_dynamics.rst
+++ b/docs/source/user_guide/benchmarks/molecular_dynamics.rst
@@ -116,3 +116,47 @@ Packmol generated
 Reference data:
 * M. Southard and D. Green, Perry’s Chemical Engineers’ Handbook, 9th Edition. McGraw-Hill Education, 2018.
 * Experimental
+
+
+Inference speed
+===============
+
+Summary
+-------
+
+Measure of model inference speed and how it scales with system size. A
+size-stratified protein dataset is used, and for each structure the model forward
+pass (energy + forces) is timed and a short molecular dynamics run is executed per
+backend.
+
+Metrics
+-------
+
+1. Forward time / atom
+
+For each structure, the mean wall-clock time of a single model forward pass
+(energy + forces) is measured, excluding warm-up passes, and divided by the number of
+atoms. The reported metric is the mean of this per-atom forward time across
+structures, in microseconds per atom. Lower is faster. The accompanying scaling plot
+shows the forward-pass time against the number of atoms, one line per model.
+
+This is a wall-clock, hardware-dependent measurement rather than a level of theory:
+results are only comparable across models run on the same hardware. The reference
+hardware is an NVIDIA H100 GPU.
+
+Computational cost
+------------------
+
+High: timing runs on GPU, scaling with the number and size of the systems.
+
+Data availability
+-----------------
+
+Input structures:
+
+* Size-stratified protein dataset (elements N, H, O, S, C).
+
+Reference data:
+
+* Not applicable: this is a wall-clock hardware measurement, not a comparison to a
+  reference level of theory.

--- a/ml_peg/analysis/molecular_dynamics/inference_speed/analyse_inference_speed.py
+++ b/ml_peg/analysis/molecular_dynamics/inference_speed/analyse_inference_speed.py
@@ -1,0 +1,208 @@
+"""Analyse the inference speed benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ase.calculators.calculator import Calculator
+from mlipaudit.io import load_model_output_from_disk
+import pytest
+
+from ml_peg.analysis.utils.decorators import build_table, plot_scatter
+from ml_peg.analysis.utils.utils import (
+    build_dispersion_name_map,
+    load_metrics_config,
+    write_struct_info,
+)
+from ml_peg.app import APP_ROOT
+from ml_peg.calcs import CALCS_ROOT
+from ml_peg.calcs.utils.mlipaudit import MlPegInferenceSpeedBenchmark
+from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_models
+
+MODELS = load_models(current_models)
+DISPERSION_NAME_MAP = build_dispersion_name_map(MODELS)
+
+BENCHMARK = MlPegInferenceSpeedBenchmark.name
+
+CALC_PATH = CALCS_ROOT / "molecular_dynamics" / "inference_speed" / "outputs"
+OUT_PATH = APP_ROOT / "data" / "molecular_dynamics" / "inference_speed"
+
+METRICS_CONFIG_PATH = Path(__file__).with_name("metrics.yml")
+DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
+    METRICS_CONFIG_PATH
+)
+
+#: Conversion factor from seconds to microseconds.
+SECONDS_TO_MICROSECONDS = 1.0e6
+
+
+def _data_input_dir() -> Path:
+    """
+    Download and return the benchmark input data directory.
+
+    Returns
+    -------
+    Path
+        Directory containing the extracted inference speed input data.
+    """
+    return download_s3_data(
+        key="inputs/molecular_dynamics/inference_speed/inference_speed.zip",
+        filename="inference_speed.zip",
+    )
+
+
+@pytest.fixture
+def analyze_results() -> dict:
+    """
+    Run the mlipaudit analysis for each model.
+
+    Returns
+    -------
+    dict
+        Mapping of model name to its ``InferenceSpeedResult``.
+    """
+    data_input_dir = _data_input_dir()
+
+    results = {}
+    for model_name in MODELS:
+        output_dir = CALC_PATH / model_name / BENCHMARK
+        if not (output_dir / "model_output.zip").exists():
+            continue
+        benchmark = MlPegInferenceSpeedBenchmark(
+            force_field=Calculator(),
+            data_input_dir=data_input_dir,
+            run_mode="standard",
+        )
+        benchmark.model_output = load_model_output_from_disk(
+            CALC_PATH / model_name, MlPegInferenceSpeedBenchmark
+        )
+        results[model_name] = benchmark.analyze()
+    return results
+
+
+@pytest.fixture
+def struct_info() -> None:
+    """Write the combined element set to ``info.json`` for filtering."""
+    data_dir = _data_input_dir() / BENCHMARK
+    write_struct_info(
+        data_path=sorted(data_dir.glob("*.xyz")),
+        out_path=OUT_PATH,
+    )
+
+
+@pytest.fixture
+@plot_scatter(
+    title="Inference speed scaling",
+    x_label="Number of atoms",
+    y_label="Forward pass time / s",
+    show_line=True,
+    show_markers=True,
+    filename=str(OUT_PATH / "figure_inference_speed_scaling.json"),
+)
+def scaling_curves(analyze_results) -> dict[str, tuple[list, list]]:
+    """
+    Get the forward-pass time scaling curve for each model.
+
+    Parameters
+    ----------
+    analyze_results
+        Mapping of model name to its ``InferenceSpeedResult``.
+
+    Returns
+    -------
+    dict[str, tuple[list, list]]
+        Per-model ``(num_atoms, forward_time)`` curves, sorted by system size and
+        restricted to structures with a successful forward pass.
+    """
+    curves = {}
+    for model_name, result in analyze_results.items():
+        if result.failed:
+            continue
+        points = [
+            (structure.num_atoms, structure.average_forward_time)
+            for structure in result.structures
+            if structure.average_forward_time is not None
+        ]
+        if not points:
+            continue
+        points.sort(key=lambda point: point[0])
+        num_atoms, forward_times = zip(*points, strict=True)
+        curves[model_name] = (list(num_atoms), list(forward_times))
+    return curves
+
+
+@pytest.fixture
+def get_forward_time_per_atom(analyze_results) -> dict[str, float]:
+    """
+    Get the mean per-atom forward-pass time for each model.
+
+    Parameters
+    ----------
+    analyze_results
+        Mapping of model name to its ``InferenceSpeedResult``.
+
+    Returns
+    -------
+    dict[str, float]
+        Mean over structures of ``average_forward_time / num_atoms``, in
+        microseconds per atom. Structures without a successful forward pass are
+        skipped.
+    """
+    per_atom_times = {}
+    for model_name, result in analyze_results.items():
+        values = [
+            structure.average_forward_time / structure.num_atoms
+            for structure in result.structures
+            if structure.average_forward_time is not None
+        ]
+        if not values:
+            continue
+        per_atom_times[model_name] = sum(values) / len(values) * SECONDS_TO_MICROSECONDS
+    return per_atom_times
+
+
+@pytest.fixture
+@build_table(
+    filename=OUT_PATH / "inference_speed_metrics_table.json",
+    metric_tooltips=DEFAULT_TOOLTIPS,
+    thresholds=DEFAULT_THRESHOLDS,
+    weights=DEFAULT_WEIGHTS,
+    mlip_name_map=DISPERSION_NAME_MAP,
+)
+def metrics(
+    scaling_curves,
+    get_forward_time_per_atom: dict[str, float],
+) -> dict[str, dict]:
+    """
+    Get all metrics.
+
+    Parameters
+    ----------
+    scaling_curves
+        Forward-pass time scaling curves for all models (triggers the scaling plot).
+    get_forward_time_per_atom
+        Mean per-atom forward-pass times for all models.
+
+    Returns
+    -------
+    dict[str, dict]
+        Metric names and values for all models.
+    """
+    return {
+        "Forward Time / Atom": get_forward_time_per_atom,
+    }
+
+
+def test_inference_speed(metrics: dict[str, dict], struct_info: None) -> None:
+    """
+    Run inference speed analysis.
+
+    Parameters
+    ----------
+    metrics : dict[str, dict]
+        Inference speed metric results provided by fixtures.
+    struct_info : None
+        Element info written to ``info.json`` for filtering.
+    """

--- a/ml_peg/analysis/molecular_dynamics/inference_speed/analyse_inference_speed.py
+++ b/ml_peg/analysis/molecular_dynamics/inference_speed/analyse_inference_speed.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from pathlib import Path
 
 from ase.calculators.calculator import Calculator
-from mlipaudit.io import load_model_output_from_disk
 import pytest
+
+pytest.importorskip("mlipaudit", reason="Please install `mlipaudit` extra")
+from mlipaudit.io import load_model_output_from_disk
 
 from ml_peg.analysis.utils.decorators import build_table, plot_scatter
 from ml_peg.analysis.utils.utils import (

--- a/ml_peg/analysis/molecular_dynamics/inference_speed/metrics.yml
+++ b/ml_peg/analysis/molecular_dynamics/inference_speed/metrics.yml
@@ -1,0 +1,8 @@
+metrics:
+  Forward Time / Atom:
+    good: 0.5
+    bad: 5.0
+    unit: µs/atom
+    weight: 1
+    tooltip: Mean wall-clock time of a single model forward pass (energy + forces) per atom, averaged across structures. Hardware-dependent (H100 reference); lower is faster.
+    level_of_theory: null

--- a/ml_peg/app/molecular_dynamics/inference_speed/app_inference_speed.py
+++ b/ml_peg/app/molecular_dynamics/inference_speed/app_inference_speed.py
@@ -1,0 +1,66 @@
+"""Run inference speed benchmark app."""
+
+from __future__ import annotations
+
+from dash import Dash
+from dash.html import Div
+
+from ml_peg.app import APP_ROOT
+from ml_peg.app.base_app import BaseApp
+from ml_peg.app.utils.build_callbacks import plot_from_table_column
+from ml_peg.app.utils.load import read_plot
+
+BENCHMARK_NAME = "InferenceSpeed"
+DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/molecular_dynamics.html#inference-speed"
+DATA_PATH = APP_ROOT / "data" / "molecular_dynamics" / "inference_speed"
+
+
+class InferenceSpeedApp(BaseApp):
+    """Inference speed benchmark app layout and callbacks."""
+
+    def register_callbacks(self) -> None:
+        """Register callbacks to app."""
+        scatter = read_plot(
+            DATA_PATH / "figure_inference_speed_scaling.json",
+            id=f"{BENCHMARK_NAME}-figure",
+        )
+
+        plot_from_table_column(
+            table_id=self.table_id,
+            plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
+            column_to_plot={"Forward Time / Atom": scatter},
+        )
+
+
+def get_app() -> InferenceSpeedApp:
+    """
+    Get inference speed benchmark app layout and callback registration.
+
+    Returns
+    -------
+    InferenceSpeedApp
+        Benchmark layout and callback registration.
+    """
+    return InferenceSpeedApp(
+        name="Inference Speed",
+        framework_ids="mlip_audit",
+        description=(
+            "Model inference speed and how it scales with system size, measured on a "
+            "size-stratified protein dataset by timing the model forward pass "
+            "(energy + forces). Wall-clock and hardware-dependent (H100 reference)."
+        ),
+        docs_url=DOCS_URL,
+        table_path=DATA_PATH / "inference_speed_metrics_table.json",
+        info_path=DATA_PATH / "info.json",
+        extra_components=[
+            Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
+        ],
+    )
+
+
+if __name__ == "__main__":
+    full_app = Dash(__name__, assets_folder=DATA_PATH.parent.parent)
+    benchmark_app = get_app()
+    full_app.layout = benchmark_app.layout
+    benchmark_app.register_callbacks()
+    full_app.run(port=8070, debug=True)

--- a/ml_peg/calcs/molecular_dynamics/inference_speed/calc_inference_speed.py
+++ b/ml_peg/calcs/molecular_dynamics/inference_speed/calc_inference_speed.py
@@ -1,0 +1,68 @@
+"""
+Measure model inference speed and how it scales with system size.
+
+For each structure in a size-stratified protein dataset, the model forward pass
+(energy + forces) is timed and a short molecular dynamics run is executed per
+backend. The timings are later aggregated into a scaling curve and a per-atom
+forward-time metric.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from warnings import warn
+
+from mlipaudit.benchmarks.inference_speed.inference_speed import (
+    InferenceSpeedModelOutput,
+)
+from mlipaudit.io import write_model_output_to_disk
+import pytest
+
+from ml_peg.calcs.utils.mlipaudit import MlPegInferenceSpeedBenchmark
+from ml_peg.calcs.utils.utils import download_s3_data
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_models
+
+MODELS = load_models(current_models)
+
+OUT_PATH = Path(__file__).parent / "outputs"
+
+
+@pytest.mark.parametrize("mlip", MODELS.items())
+def test_inference_speed(mlip: tuple[str, Any]) -> None:
+    """
+    Benchmark model inference speed.
+
+    Parameters
+    ----------
+    mlip
+        Name of model and model object to get calculator.
+    """
+    model_name, model = mlip
+    calc = model.get_calculator()
+    calc = model.add_d3_calculator(calc)
+
+    data_input_dir = download_s3_data(
+        key="inputs/molecular_dynamics/inference_speed/inference_speed.zip",
+        filename="inference_speed.zip",
+    )
+
+    benchmark = MlPegInferenceSpeedBenchmark(
+        force_field=calc,
+        data_input_dir=data_input_dir,
+        run_mode="standard",
+    )
+    try:
+        benchmark.run_model()
+    except Exception as exc:
+        warn(
+            f"Error running inference speed benchmark for {model_name}: {exc}",
+            stacklevel=2,
+        )
+        # Empty structure lists are treated as a failed benchmark by analyze().
+        benchmark.model_output = InferenceSpeedModelOutput(structure_names=[])
+
+    write_model_output_to_disk(
+        "inference_speed", benchmark.model_output, OUT_PATH / model_name
+    )

--- a/ml_peg/calcs/molecular_dynamics/inference_speed/calc_inference_speed.py
+++ b/ml_peg/calcs/molecular_dynamics/inference_speed/calc_inference_speed.py
@@ -13,11 +13,13 @@ from pathlib import Path
 from typing import Any
 from warnings import warn
 
+import pytest
+
+pytest.importorskip("mlipaudit", reason="Please install `mlipaudit` extra")
 from mlipaudit.benchmarks.inference_speed.inference_speed import (
     InferenceSpeedModelOutput,
 )
 from mlipaudit.io import write_model_output_to_disk
-import pytest
 
 from ml_peg.calcs.utils.mlipaudit import MlPegInferenceSpeedBenchmark
 from ml_peg.calcs.utils.utils import download_s3_data

--- a/ml_peg/calcs/utils/mlipaudit.py
+++ b/ml_peg/calcs/utils/mlipaudit.py
@@ -5,11 +5,25 @@ from __future__ import annotations
 from mlipaudit.benchmarks.conformer_selection.conformer_selection import (
     ConformerSelectionBenchmark,
 )
+from mlipaudit.benchmarks.inference_speed.inference_speed import (
+    InferenceSpeedBenchmark,
+)
 
 
 class MlPegConformerSelectionBenchmark(ConformerSelectionBenchmark):
     """
     ConformerSelectionBenchmark wired up for ml-peg's ASE calculators.
+
+    ``skip_if_elements_missing`` is disabled because ASE ``Calculator`` objects
+    do not expose ``allowed_atomic_numbers``.
+    """
+
+    skip_if_elements_missing = False
+
+
+class MlPegInferenceSpeedBenchmark(InferenceSpeedBenchmark):
+    """
+    InferenceSpeedBenchmark wired up for ml-peg's ASE calculators.
 
     ``skip_if_elements_missing`` is disabled because ASE ``Calculator`` objects
     do not expose ``allowed_atomic_numbers``.

--- a/ml_peg/calcs/utils/mlipaudit.py
+++ b/ml_peg/calcs/utils/mlipaudit.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from mlipaudit.benchmarks.conformer_selection.conformer_selection import (
+from mlipaudit.benchmarks import (
     ConformerSelectionBenchmark,
+    InferenceSpeedBenchmark,
+    TautomersBenchmark,
 )
-from mlipaudit.benchmarks import InferenceSpeedBenchmark
-from mlipaudit.benchmarks.tautomers.tautomers import TautomersBenchmark
 
 
 class MlPegConformerSelectionBenchmark(ConformerSelectionBenchmark):

--- a/ml_peg/calcs/utils/mlipaudit.py
+++ b/ml_peg/calcs/utils/mlipaudit.py
@@ -5,12 +5,24 @@ from __future__ import annotations
 from mlipaudit.benchmarks.conformer_selection.conformer_selection import (
     ConformerSelectionBenchmark,
 )
+from mlipaudit.benchmarks import InferenceSpeedBenchmark
 from mlipaudit.benchmarks.tautomers.tautomers import TautomersBenchmark
 
 
 class MlPegConformerSelectionBenchmark(ConformerSelectionBenchmark):
     """
     ConformerSelectionBenchmark wired up for ml-peg's ASE calculators.
+
+    ``skip_if_elements_missing`` is disabled because ASE ``Calculator`` objects
+    do not expose ``allowed_atomic_numbers``.
+    """
+
+    skip_if_elements_missing = False
+
+
+class MlPegInferenceSpeedBenchmark(InferenceSpeedBenchmark):
+    """
+    InferenceSpeedBenchmark wired up for ml-peg's ASE calculators.
 
     ``skip_if_elements_missing`` is disabled because ASE ``Calculator`` objects
     do not expose ``allowed_atomic_numbers``.


### PR DESCRIPTION
## Pre-review checklist for PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [x] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [x] I have added human-written tests for the new logic.
- [x] I have properly cited any upstream algorithms or libraries the AI utilized.
- [x] I have disclosed significant AI tool usage in the PR description.

## Summary

Migrates the **inference speed** benchmark from the MLIP Audit suite into ml-peg under the `molecular_dynamics` category.

For each structure in a size-stratified protein dataset (elements N, H, O, S, C), the underlying `InferenceSpeedBenchmark` times the model forward pass (energy + forces) and runs a short MD simulation per backend. This PR wires that up for ml-peg's ASE calculators and exposes:

- **Table metric** `Forward Time / Atom` (µs/atom, lower is better): mean over structures of `average_forward_time / num_atoms`, skipping structures whose forward pass failed.
- **Scaling plot** (line plot): forward-pass time (s) vs. number of atoms, one line per model, sorted by system size and restricted to successful forward passes.

This is a wall-clock, **hardware-dependent** measurement (H100 reference), not a level of theory, so results are only comparable across models run on the same hardware.

## :warning: Blocked

**This PR is blocked and must remain a draft until the `inference_speed` benchmark lands on the mlipaudit `mlpeg-migration` branch.**

- ml-peg pins mlipaudit to the `mlpeg-migration` branch (it carries the ASE `BaseCalculator` fix and other changes the rest of ml-peg needs). That pin is intentionally **left unchanged** here.
- `InferenceSpeedBenchmark` currently exists only on the mlipaudit branch `feat/scaling-benchmark-revamp`, at `src/mlipaudit/benchmarks/inference_speed/inference_speed.py`. It is **not** on `mlpeg-migration`.
- Until `inference_speed` is merged into `mlpeg-migration`, the import `from mlipaudit.benchmarks.inference_speed.inference_speed import ...` will not resolve, so the benchmark cannot run.

Additional notes:
- The shared mlipaudit wiring (the `mlipaudit` optional extra + conflicts entry in `pyproject.toml`, the `[tool.uv.sources]` pin, and the `mlip_audit` entry in `frameworks.yml`) is **already present on `main`** and overlaps with other in-flight mlipaudit PRs, so this PR does not touch those files.
- **Data packaging requirement:** the S3 object `inputs/molecular_dynamics/inference_speed/inference_speed.zip` must contain an `inference_speed/` directory of size-prefixed `.xyz` files (e.g. `121_1ay3.xyz`) — the benchmark reads `data_dir / "{structure}.xyz"` from `data_input_dir / "inference_speed"`.

## Linked issue

Resolves #742

## Progress

- [x] Calculations
- [x] Analysis
- [x] Application
- [x] Documentation

## Testing

Static checks only so far: `python -m py_compile` on the new modules and all `pre-commit` hooks (ruff-check, ruff-format, numpydoc-validation, whitespace/EOF) pass.

End-to-end testing is **pending two prerequisites**:
1. The mlipaudit dependency landing on `mlpeg-migration` (see Blocked above).
2. The S3 data upload of `inputs/molecular_dynamics/inference_speed/inference_speed.zip`.

The `good`/`bad` thresholds in `metrics.yml` (0.5 / 5.0 µs/atom) and the score midpoint are **estimates** and need tuning against real H100 runs.

## New decorators/callbacks

None. Reuses the existing `@plot_scatter` (line plot), `@build_table`, and `plot_from_table_column` / `read_plot` patterns.
