### PR TITLE
Enable float64 precision for FairChem (UMA) calculators

### DIFF
--- a/ml_peg/models/models.py
+++ b/ml_peg/models/models.py
@@ -216,17 +216,19 @@ class FairChemCalc(SumCalc):
     model_name: str
     task_name: str
     device: Device | str = "cpu"
-    default_dtype: str = "float32"
+    default_dtype: str | None = None
     overrides: dict = dataclasses.field(default_factory=dict)
 
-    def get_calculator(self, **kwargs) -> Calculator:
+    def get_calculator(self, precision="high", **kwargs) -> Calculator:
         """
         Prepare and load the calculator.
 
         Parameters
         ----------
+        precision
+            Level of precision to evaluate the model.
         **kwargs
-            Unused additional keyword arguments.
+            Any additional keyword arguments.
 
         Returns
         -------
@@ -234,10 +236,24 @@ class FairChemCalc(SumCalc):
             Loaded ASE fairchem Calculator.
         """
         from fairchem.core import FAIRChemCalculator, pretrained_mlip
-        # torch.serialization.add_safe_globals([slice])
+        from fairchem.core.units.mlip_unit.api.inference import (
+            inference_settings_default,
+        )
+
+        # fairchem defaults to float32; map the requested precision to the base
+        # dtype so precision="high" runs in float64. A configured default_dtype
+        # overrides this.
+        precision_map = {"low": "float32", "high": "float64"}
+        dtype = self.default_dtype or precision_map[precision]
+        inference_settings = dataclasses.replace(
+            inference_settings_default(), base_precision_dtype=dtype
+        )
 
         predictor = pretrained_mlip.get_predict_unit(
-            self.model_name, device=self.device, overrides=self.overrides
+            self.model_name,
+            device=self.device,
+            overrides=self.overrides,
+            inference_settings=inference_settings,
         )
         return FAIRChemCalculator(predictor, task_name=self.task_name)
 


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [X] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [ ] I have added human-written tests for the new logic.
- [X] I have properly cited any upstream algorithms or libraries the AI utilized.
- [X] I have disclosed significant AI tool usage in the PR description.

## Summary

FairChemCalc.get_calculator` ignored the `precision` argument that the rest of ML-PEG passes, so UMA/FairChem models always ran in FairChem's default float32, even with `precision="high"`. 

This makes `FairChemCalc` honour `precision` the same way the sibling calculators (`MaceCalc`, `PetMadCalc`, `OrbCalc`) already do: `precision` is mapped to a dtype (`high → float64`, `low → float32`) and applied by replacing `base_precision_dtype` on FairChem's default `InferenceSettings`, which is passed to `get_predict_unit`. `default_dtype` becomes an optional per-model override instead of a hardcoded float32.

## Linked issue

Resolves #756 

## Testing

Verified manually: for uma-s-1p1 on H₂O, precision="high" and precision="low" now give different forces (max abs diff ~1.9e-6), whereas before the fix they were bit-identical (both float32). 

