### PR TITLE
Fix filter docs import and indent

### DIFF
--- a/docs/source/developer_guide/filter.rst
+++ b/docs/source/developer_guide/filter.rst
@@ -80,7 +80,7 @@ can be used:
 
 .. code-block:: python
 
-    from ml_peg.app.utils.utils import write_struct_info
+    from ml_peg.analysis.utils.utils import write_struct_info
 
     def test_benchmark(metrics):
         write_struct_info(
@@ -100,7 +100,7 @@ elements should be saved for each. This can be done using ``get_struct_info``:
 
 .. code-block:: python
 
-    from ml_peg.app.utils.utils import get_struct_info
+    from ml_peg.analysis.utils.utils import get_struct_info
 
     SYSTEM_INFO = get_struct_info(
         calc_path=CALC_PATH,
@@ -114,7 +114,7 @@ elements should be saved for each. This can be done using ``get_struct_info``:
 
 Since tests of this form often require labels to be extracted for hoverdata, this
 function also provides the option to save lists of keys saved to ``Atoms.info`` through
- the ``info_keys`` option, as well as the filename stems using ``include_filenames``.
+the ``info_keys`` option, as well as the filename stems using ``include_filenames``.
 
 Instead of a single list of elements, this will save elements as a list of lists in
 ``OUT_PATH / "info.json"``, as well as storing the other extracted informaiton in the


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [x] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [x] I have added human-written tests for the new logic.
- [x] I have properly cited any upstream algorithms or libraries the AI utilized.
- [x] I have disclosed significant AI tool usage in the PR description.

## Summary

Fixes incorrect example imports for filtering, and an unintended import that raises a warning.

## Testing

Docs build locally with no warnings.
