### PR TITLE
Fix MatterSimCalculator copy() crash on non-default checkpoints

### DIFF
--- a/ml_peg/models/models.py
+++ b/ml_peg/models/models.py
@@ -140,6 +140,40 @@ class GenericASECalc(SumCalc, MlipxGenericASECalc):
         return MlipxGenericASECalc.get_calculator(self, **kwargs)
 
 
+def _patch_mattersim_setstate() -> None:
+    """Rebuild the model from mattersim's own saved model_args on copy()."""
+    from mattersim.forcefield.m3gnet.m3gnet import M3Gnet
+    from mattersim.forcefield.potential import MatterSimCalculator, Potential
+    import torch
+
+    def __setstate__(self, state):  # noqa: N807
+        """
+        Restore from copy/pickle by rebuilding at the saved architecture.
+
+        Parameters
+        ----------
+        self
+            The ``MatterSimCalculator`` instance being restored.
+        state
+            State dict produced by ``__getstate__``, containing the saved
+            model weights, architecture (``model_args``) and name.
+        """
+        model_state_dict = state.pop("_model_state_dict")
+        model_args = state.pop("_model_args")
+        model_name = state.pop("_model_name")
+        self.__dict__.update(state)
+        model = M3Gnet(device=self.device, **model_args).to(self.device)
+        model.load_state_dict(model_state_dict)
+        model.eval()
+        self.potential = Potential(
+            model, device=self.device, model_name=model_name, load_training_state=False
+        )
+        if self.dtype == torch.float64:
+            self.potential.model.double()
+
+    MatterSimCalculator.__setstate__ = __setstate__
+
+
 @dataclasses.dataclass(kw_only=True)
 class MatterSimCalc(GenericASECalc):
     """Dataclass for MatterSim calculator."""
@@ -165,6 +199,8 @@ class MatterSimCalc(GenericASECalc):
 
         if self.default_dtype is not None:
             kwargs["dtype"] = self.default_dtype
+
+        _patch_mattersim_setstate()
 
         return MlipxGenericASECalc.get_calculator(self, **kwargs)
 


### PR DESCRIPTION
## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [X] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [X] I have added human-written tests for the new logic.
- [X] I have properly cited any upstream algorithms or libraries the AI utilized.
- [X] I have disclosed significant AI tool usage in the PR description.

## Summary

Patches MatterSimCalculator.__setstate__ (mattersim's own code) to rebuild the model from its saved model_args on copy.copy(), instead of always defaulting to the wrong (1M/128-unit) architecture regardless of which checkpoint was actually loaded. Fixes a crash affecting any benchmark using the standard copy(calc) pattern with mattersim-5M (or any non-default MatterSim checkpoint).

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #771 

## Testing

Standalone (no ml-peg): confirmed copy.copy(MatterSimCalculator(load_path="mattersim-v1.0.0-5m")) crashes on plain mattersim==1.2.4, and that mattersim's own __setstate__ source never uses the model_args it saves (confirming root cause before fixing).
After the patch: copied calculator's parameters and predictions are bitwise-identical to the original (not just crash-free).
Verified before/after on three independent benchmarks - each fails identically without the fix, passes with it: translational_symmetry, extensivity, SBH17 

## AI tool usage disclosure
This investigation, root-cause diagnosis, and fix were developed with assistance from Claude (Anthropic)