### PR TITLE
Add battery electrolyte densities benchmark

### DIFF
--- a/docs/source/user_guide/benchmarks/molecular_dynamics.rst
+++ b/docs/source/user_guide/benchmarks/molecular_dynamics.rst
@@ -116,3 +116,52 @@ Packmol generated
 Reference data:
 * M. Southard and D. Green, Perry’s Chemical Engineers’ Handbook, 9th Edition. McGraw-Hill Education, 2018.
 * Experimental
+
+Battery electrolyte densities
+=============================
+
+Summary
+-------
+
+Performance in predicting the densities of 25 battery electrolyte systems at
+298.2 K: six neat glyme and carbonate solvents (DME, DEGDME, TEGDME, PC, DEG,
+DMC), and 19 electrolytes formed from NaPF6, NaOTf, NaTFSI and KPF6 at 0.1, 0.5
+and 1.0 M. Systems contain roughly 500-2200 atoms.
+
+Because the same salts appear across several solvents and concentrations, the
+benchmark separates general liquid-density performance from the harder question
+of whether a potential handles concentrated ionic environments.
+
+Metrics
+-------
+
+1. Density MAE
+2. Density RMSE
+3. Density MAPE
+
+For each system, the density is the average over an NPT molecular dynamics run
+at 298.2 K and 1 atm with a 1 fs timestep. The first 50 ps of each 150 ps
+trajectory is discarded, leaving 100 ps of production. Inputs are already
+NPT-equilibrated, which is why a shorter equilibration period is used than for
+the organic liquid densities benchmark. Densities are compared to experimental
+values at 298.2 K.
+
+Computational cost
+------------------
+
+High: 150 ps of NPT MD per system, for 25 systems per model.
+
+Data availability
+-----------------
+
+Input structures:
+
+* Kumar et al., Prediction and Experimental Verification of Electrolyte
+  Solvation Structure from an OMol25-Trained Interatomic Potential.
+  arXiv:2603.20183 [physics.chem-ph]
+* https://github.com/KMNitesh05/sodium-ion-battery-electrolyte-dataset
+
+Reference data:
+
+* Same as input data
+* Experimental

--- a/ml_peg/analysis/molecular_dynamics/battery_electrolyte_densities/analyse_battery_electrolyte_densities.py
+++ b/ml_peg/analysis/molecular_dynamics/battery_electrolyte_densities/analyse_battery_electrolyte_densities.py
@@ -1,0 +1,272 @@
+"""Analyse the battery electrolyte densities benchmark."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ase import units
+from ase.io import Trajectory, write
+import numpy as np
+import pytest
+
+from ml_peg.analysis.utils.decorators import build_table, plot_parity
+from ml_peg.analysis.utils.utils import (
+    build_dispersion_name_map,
+    get_struct_info,
+    load_metrics_config,
+    mae,
+    rmse,
+)
+from ml_peg.app import APP_ROOT
+from ml_peg.calcs import CALCS_ROOT
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_models
+
+MODELS = load_models(current_models)
+D3_MODEL_NAMES = build_dispersion_name_map(MODELS)
+
+# Must match LOG_INTERVAL * TIMESTEP in calc_battery_electrolyte_densities.py.
+LOG_INTERVAL_PS = 0.1
+
+# Portion of each trajectory discarded before averaging, leaving 100 ps of
+# production. The inputs are already NPT-equilibrated, so this only needs to
+# cover relaxation into the new potential energy surface. Protocol from
+# ddmms/ml-peg#358.
+EQUILIB_TIME_PS = 50
+
+BENCHMARK = "battery_electrolyte_densities"
+CALC_PATH = CALCS_ROOT / "molecular_dynamics" / BENCHMARK / "outputs"
+OUT_PATH = APP_ROOT / "data" / "molecular_dynamics" / BENCHMARK
+
+METRICS_CONFIG_PATH = Path(__file__).with_name("metrics.yml")
+DEFAULT_THRESHOLDS, DEFAULT_TOOLTIPS, DEFAULT_WEIGHTS = load_metrics_config(
+    METRICS_CONFIG_PATH
+)
+
+INFO = get_struct_info(
+    calc_path=CALC_PATH,
+    glob_pattern="*.traj",
+    index=0,
+    info_keys=["exp_density", "concentration_M", "category", "salt", "solvent"],
+    write_info=True,
+    write_structs=True,
+    out_path=OUT_PATH,
+    include_filenames=True,
+)
+
+
+def compute_density(traj_path: Path) -> float:
+    """
+    Compute the average density over the production part of an NPT trajectory.
+
+    Densities are recomputed from the stored cells rather than parsed out of the
+    text log, so the result does not depend on the log format and a truncated
+    log cannot silently change the answer.
+
+    Parameters
+    ----------
+    traj_path
+        Path to the ASE trajectory file.
+
+    Returns
+    -------
+    float
+        Average density in g/cm^3, or NaN if the trajectory is shorter than the
+        discarded equilibration period.
+    """
+    au_to_g_cm3 = 1e24 / units.mol
+    skip_frames = int(EQUILIB_TIME_PS / LOG_INTERVAL_PS)
+
+    traj = Trajectory(traj_path)
+    if len(traj) <= skip_frames:
+        return np.nan
+
+    densities = [
+        au_to_g_cm3 * atoms.get_masses().sum() / atoms.get_volume()
+        for atoms in traj[skip_frames:]
+    ]
+    return float(np.mean(densities))
+
+
+def mape(ref: list, prediction: list) -> float:
+    """
+    Get mean absolute percentage error.
+
+    ML-PEG's analysis utilities provide MAE and RMSE but not MAPE, so it is
+    defined here. NaN handling matches those helpers: any NaN prediction makes
+    the whole metric NaN, so a failed system cannot be hidden by averaging.
+
+    Parameters
+    ----------
+    ref
+        Reference data.
+    prediction
+        Predicted data.
+
+    Returns
+    -------
+    float
+        Mean absolute percentage error, in percent.
+    """
+    if np.isnan(np.sum(prediction)):
+        return np.nan
+
+    ref_arr = np.asarray(ref, dtype=float)
+    pred_arr = np.asarray(prediction, dtype=float)
+    return float(100 * np.mean(np.abs((ref_arr - pred_arr) / ref_arr)))
+
+
+@pytest.fixture
+@plot_parity(
+    filename=OUT_PATH / "figure_battery_electrolyte_densities.json",
+    title="Battery electrolyte densities",
+    x_label="Reference density / g cm<sup>-3</sup>",
+    y_label="Predicted density / g cm<sup>-3</sup>",
+    hoverdata={
+        "Labels": INFO["filenames"],
+        "Salt": INFO["salt"],
+        "Solvent": INFO["solvent"],
+        "Concentration / M": INFO["concentration_M"],
+    },
+    symbol_by=INFO["category"],
+)
+def densities() -> dict[str, list]:
+    """
+    Get battery electrolyte densities for all systems.
+
+    Returns
+    -------
+    dict[str, list]
+        Dictionary of all reference and predicted densities.
+    """
+    results = {"ref": []} | {mlip: [] for mlip in MODELS}
+    ref_stored = False
+
+    for model_name in MODELS:
+        for label in INFO["filenames"]:
+            traj_path = CALC_PATH / model_name / f"{label}.traj"
+            results[model_name].append(compute_density(traj_path))
+
+            atoms = Trajectory(traj_path)[-1]
+            if not ref_stored:
+                results["ref"].append(atoms.info["exp_density"])
+
+            # Write structures for app
+            structs_dir = OUT_PATH / model_name
+            structs_dir.mkdir(parents=True, exist_ok=True)
+            write(structs_dir / f"{label}.xyz", atoms)
+        ref_stored = True
+
+    return results
+
+
+@pytest.fixture
+def get_mae(densities: dict[str, list]) -> dict[str, float]:
+    """
+    Get mean absolute error for densities.
+
+    Parameters
+    ----------
+    densities
+        Dictionary of reference and predicted densities.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary of density errors for all models.
+    """
+    return {
+        model_name: mae(densities["ref"], densities[model_name])
+        for model_name in MODELS
+    }
+
+
+@pytest.fixture
+def get_rmse(densities: dict[str, list]) -> dict[str, float]:
+    """
+    Get root mean squared error for densities.
+
+    Parameters
+    ----------
+    densities
+        Dictionary of reference and predicted densities.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary of density errors for all models.
+    """
+    return {
+        model_name: rmse(densities["ref"], densities[model_name])
+        for model_name in MODELS
+    }
+
+
+@pytest.fixture
+def get_mape(densities: dict[str, list]) -> dict[str, float]:
+    """
+    Get mean absolute percentage error for densities.
+
+    Parameters
+    ----------
+    densities
+        Dictionary of reference and predicted densities.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary of density errors for all models.
+    """
+    return {
+        model_name: mape(densities["ref"], densities[model_name])
+        for model_name in MODELS
+    }
+
+
+@pytest.fixture
+@build_table(
+    filename=OUT_PATH / "battery_electrolyte_densities_metrics_table.json",
+    metric_tooltips=DEFAULT_TOOLTIPS,
+    thresholds=DEFAULT_THRESHOLDS,
+    mlip_name_map=D3_MODEL_NAMES,
+)
+def metrics(
+    get_mae: dict[str, float],
+    get_rmse: dict[str, float],
+    get_mape: dict[str, float],
+) -> dict[str, dict]:
+    """
+    Get all metrics.
+
+    Parameters
+    ----------
+    get_mae
+        Mean absolute errors for all models.
+    get_rmse
+        Root mean squared errors for all models.
+    get_mape
+        Mean absolute percentage errors for all models.
+
+    Returns
+    -------
+    dict[str, dict]
+        Metric names and values for all models.
+    """
+    return {
+        "MAE": get_mae,
+        "RMSE": get_rmse,
+        "MAPE": get_mape,
+    }
+
+
+@pytest.mark.framework("omol25-electrolytes")
+def test_battery_electrolyte_densities(metrics: dict[str, dict]) -> None:
+    """
+    Run battery electrolyte densities test.
+
+    Parameters
+    ----------
+    metrics
+        All new benchmark metric names and dictionary of values for each model.
+    """
+    return

--- a/ml_peg/analysis/molecular_dynamics/battery_electrolyte_densities/metrics.yml
+++ b/ml_peg/analysis/molecular_dynamics/battery_electrolyte_densities/metrics.yml
@@ -1,0 +1,19 @@
+metrics:
+  MAE:
+    good: 0.0
+    bad: 0.1
+    unit: g/cm^3
+    tooltip: Mean absolute error in NPT density over all 25 systems
+    level_of_theory: Experimental
+  RMSE:
+    good: 0.0
+    bad: 0.1
+    unit: g/cm^3
+    tooltip: Root mean squared error in NPT density over all 25 systems
+    level_of_theory: Experimental
+  MAPE:
+    good: 0.0
+    bad: 10.0
+    unit: "%"
+    tooltip: Mean absolute percentage error in NPT density over all 25 systems
+    level_of_theory: Experimental

--- a/ml_peg/app/molecular_dynamics/battery_electrolyte_densities/app_battery_electrolyte_densities.py
+++ b/ml_peg/app/molecular_dynamics/battery_electrolyte_densities/app_battery_electrolyte_densities.py
@@ -1,0 +1,95 @@
+"""Run battery electrolyte densities app."""
+
+from __future__ import annotations
+
+from dash import Dash
+from dash.html import Div
+
+from ml_peg.app import APP_ROOT
+from ml_peg.app.base_app import BaseApp
+from ml_peg.app.utils.build_callbacks import (
+    plot_from_table_column,
+    struct_from_scatter,
+)
+from ml_peg.app.utils.load import read_plot
+from ml_peg.models import current_models
+from ml_peg.models.get_models import get_model_names
+
+MODELS = get_model_names(current_models)
+BENCHMARK_NAME = "Battery Electrolyte Densities"
+DOCS_URL = (
+    "https://ddmms.github.io/ml-peg/user_guide/benchmarks/molecular_dynamics.html"
+    "#battery-electrolyte-densities"
+)
+DATA_PATH = APP_ROOT / "data" / "molecular_dynamics" / "battery_electrolyte_densities"
+INFO_PATH = DATA_PATH / "info.json"
+
+
+class BatteryElectrolyteDensitiesApp(BaseApp):
+    """Battery electrolyte densities benchmark app layout and callbacks."""
+
+    def register_callbacks(self) -> None:
+        """Register callbacks to app."""
+        scatter = read_plot(
+            DATA_PATH / "figure_battery_electrolyte_densities.json",
+            id=f"{BENCHMARK_NAME}-figure",
+        )
+
+        model_dir = DATA_PATH / MODELS[0]
+        if model_dir.exists():
+            labels = sorted([f.stem for f in model_dir.glob("*.xyz")])
+            structs = [
+                "/assets/molecular_dynamics/battery_electrolyte_densities/"
+                f"{MODELS[0]}/{label}.xyz"
+                for label in labels
+            ]
+        else:
+            structs = []
+
+        plot_from_table_column(
+            table_id=self.table_id,
+            plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
+            column_to_plot={"MAE": scatter},
+        )
+
+        struct_from_scatter(
+            scatter_id=f"{BENCHMARK_NAME}-figure",
+            struct_id=f"{BENCHMARK_NAME}-struct-placeholder",
+            structs=structs,
+            mode="struct",
+        )
+
+
+def get_app() -> BatteryElectrolyteDensitiesApp:
+    """
+    Get battery electrolyte densities benchmark app layout and callbacks.
+
+    Returns
+    -------
+    BatteryElectrolyteDensitiesApp
+        Benchmark layout and callback registration.
+    """
+    return BatteryElectrolyteDensitiesApp(
+        name=BENCHMARK_NAME,
+        description=(
+            "Performance in predicting densities of Na-ion battery electrolytes "
+            "in glyme and carbonate solvents, and of the corresponding neat "
+            "solvents. Reference data are experimental densities at 298.2 K."
+        ),
+        docs_url=DOCS_URL,
+        table_path=DATA_PATH / "battery_electrolyte_densities_metrics_table.json",
+        extra_components=[
+            Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
+            Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
+        ],
+        info_path=INFO_PATH,
+        framework_ids="omol25-electrolytes",
+    )
+
+
+if __name__ == "__main__":
+    full_app = Dash(__name__, assets_folder=DATA_PATH.parent.parent)
+    benchmark_app = get_app()
+    full_app.layout = benchmark_app.layout
+    benchmark_app.register_callbacks()
+    full_app.run(port=8064, debug=True)

--- a/ml_peg/app/utils/frameworks.yml
+++ b/ml_peg/app/utils/frameworks.yml
@@ -33,3 +33,12 @@ mace-polar-1:
   url: "https://arxiv.org/abs/2602.19411"
   icon: "📄"
   tooltip: "Benchmark from the MACE-POLAR-1 paper (arXiv:2602.19411) - click to read"
+
+
+omol25-electrolytes:
+  label: OMol25 Electrolytes
+  color: "#0f766e"
+  text_color: "#ecfeff"
+  url: "https://arxiv.org/abs/2603.20183"
+  icon: "📄"
+  tooltip: "Benchmark from the OMol25 electrolyte solvation paper (arXiv:2603.20183) - click to read"

--- a/ml_peg/calcs/molecular_dynamics/battery_electrolyte_densities/calc_battery_electrolyte_densities.py
+++ b/ml_peg/calcs/molecular_dynamics/battery_electrolyte_densities/calc_battery_electrolyte_densities.py
@@ -1,0 +1,252 @@
+"""
+Calculate densities using NPT of 25 battery electrolyte systems.
+
+Systems are Na-ion (plus one K-ion reference) battery electrolytes in glyme and
+carbonate solvents, together with the corresponding neat solvents, taken from
+arXiv:2603.20183. Reference data are experimental densities at 298.2 K.
+
+Configurations were equilibrated under NPT with OPLS-AA and the OMol25-trained
+UMA potential, and are distributed at
+https://github.com/KMNitesh05/sodium-ion-battery-electrolyte-dataset
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import time
+from typing import Any
+from warnings import warn
+
+from ase import Atoms, units
+from ase.io import Trajectory, read
+from ase.md.nose_hoover_chain import IsotropicMTKNPT
+from ase.md.velocitydistribution import MaxwellBoltzmannDistribution, Stationary
+import numpy as np
+import pytest
+
+from ml_peg.calcs.utils.utils import download_github_data
+from ml_peg.models import current_models
+from ml_peg.models.get_models import load_models
+
+MODELS = load_models(current_models)
+
+OUT_PATH = Path(__file__).parent / "outputs"
+
+AU_TO_G_CM3 = 1e24 / units.mol
+ATM = 1.01325 * units.bar
+
+# Number of configurations in the dataset.
+N_SYSTEMS = 25
+
+# 150 ps of NPT per system: 50 ps equilibration, discarded during analysis, then
+# 100 ps of production. This is the protocol proposed in ddmms/ml-peg#358, and is
+# shorter than the 1 ns used by liquid_densities because these inputs arrive
+# already NPT-equilibrated with a potential of comparable quality.
+NUM_MD_STEPS = 150_000
+TIMESTEP = 1 * units.fs
+LOG_INTERVAL = 100
+
+# The reference densities come from a study using dispersion-inclusive models,
+# and adding D3 on top of those would double-count. Set to True to apply the
+# runtime D3 correction as liquid_densities does.
+ADD_D3 = False
+
+DATA_ZIP = "battery_electrolyte_densities.zip"
+DATA_URI = (
+    "https://raw.githubusercontent.com/KMNitesh05/"
+    "sodium-ion-battery-electrolyte-dataset/main/data"
+)
+
+
+def get_density_g_cm3(atoms: Atoms) -> float:
+    """
+    Get the density of the system in g/cm^3.
+
+    Parameters
+    ----------
+    atoms
+        ASE Atoms object of the periodic system.
+
+    Returns
+    -------
+    float
+        Density in g/cm^3.
+    """
+    mass = atoms.get_masses().sum()
+    volume = atoms.get_volume()
+    return AU_TO_G_CM3 * mass / volume
+
+
+def log_md(dyn, start_time: float) -> None:
+    """
+    Log molecular dynamics simulation.
+
+    The 15 whitespace-separated fields per line match the liquid_densities
+    benchmark, so the same log parsing works for both.
+
+    Parameters
+    ----------
+    dyn
+        ASE molecular dynamics object.
+    start_time
+        Real time of the simulation start, in seconds.
+    """
+    current_time = time.time() - start_time
+    energy = dyn.atoms.get_potential_energy()
+    density = get_density_g_cm3(dyn.atoms)
+    temperature = dyn.atoms.get_temperature()
+    t = dyn.get_time() / (1000 * units.fs)
+    logging.info(
+        f"""t: {t:>8.3f} ps\
+            Walltime: {current_time:>10.3f} s\
+            T: {temperature:.1f} K\
+            Epot: {energy:.2f} eV\
+            density: {density:.5f} g/cm^3\
+        """
+    )
+
+
+def init_velocities(atoms: Atoms, temperature_k: float) -> None:
+    """
+    Give the system a Maxwell-Boltzmann velocity distribution if it has none.
+
+    Some configurations in the dataset carry momenta from their equilibration
+    run and some do not. Starting an NPT run from zero velocities would waste a
+    large part of the trajectory on heating, so seed them here when absent.
+
+    Parameters
+    ----------
+    atoms
+        ASE Atoms object to initialise velocities for.
+    temperature_k
+        Target temperature in K.
+    """
+    if atoms.has("momenta") and np.any(atoms.get_momenta()):
+        return
+
+    MaxwellBoltzmannDistribution(atoms, temperature_K=temperature_k)
+    Stationary(atoms)
+
+
+def run_npt(atoms: Atoms, calc, output_fname: Path) -> None:
+    """
+    Run NPT molecular dynamics using the isotropic MTK barostat.
+
+    Restarts from the last frame of an existing trajectory, so a benchmark run
+    that hit a walltime limit can be resumed by rerunning the same command.
+
+    Parameters
+    ----------
+    atoms
+        ASE Atoms of the system.
+    calc
+        ASE Calculator.
+    output_fname
+        File name to save the trajectory to.
+    """
+    if Path(output_fname).exists():
+        try:
+            traj = Trajectory(output_fname)
+            atoms = traj[-1]
+            nsteps = (len(traj) - 1) * LOG_INTERVAL
+        except Exception as exc:
+            print(exc)
+            nsteps = 0
+    else:
+        nsteps = 0
+
+    atoms.calc = calc
+    # Set default charge and spin
+    atoms.info.setdefault("charge", 0)
+    atoms.info.setdefault("spin", 1)
+
+    temperature_k = atoms.info["exp_temperature"]
+    if nsteps == 0:
+        init_velocities(atoms, temperature_k)
+
+    dyn = IsotropicMTKNPT(
+        atoms=atoms,
+        timestep=TIMESTEP,
+        temperature_K=temperature_k,
+        pressure_au=ATM,
+        tdamp=50 * units.fs,
+        pdamp=500 * units.fs,
+        trajectory=output_fname,
+        loginterval=LOG_INTERVAL,
+        append_trajectory=True,
+    )
+    dyn.nsteps = nsteps
+    dyn.attach(log_md, interval=LOG_INTERVAL, dyn=dyn, start_time=time.time())
+    try:
+        dyn.run(steps=NUM_MD_STEPS - nsteps)
+    except Exception as exc:
+        warn(f"Error running MD: {exc}", stacklevel=2)
+        dyn.atoms.info["energy"] = np.nan
+
+
+def get_structure_paths() -> list[Path]:
+    """
+    Download the dataset and return its structure files in a fixed order.
+
+    Returns
+    -------
+    list[Path]
+        Sorted paths to the equilibrated configurations. The index into this
+        list is the ``--system-id`` of the corresponding system.
+    """
+    data_path = (
+        download_github_data(filename=DATA_ZIP, github_uri=DATA_URI)
+        / "battery_electrolyte_densities"
+    )
+    paths = sorted((data_path / "structures").glob("*.xyz"))
+
+    if len(paths) != N_SYSTEMS:
+        raise ValueError(
+            f"Expected {N_SYSTEMS} structures in {data_path / 'structures'}, "
+            f"found {len(paths)}"
+        )
+
+    return paths
+
+
+@pytest.mark.framework("omol25-electrolytes")
+@pytest.mark.very_slow
+@pytest.mark.parametrize("mlip", MODELS.items())
+def test_battery_electrolyte_densities(mlip: tuple[str, Any], system_id: int) -> None:
+    """
+    Run battery electrolyte densities benchmark.
+
+    Parameters
+    ----------
+    mlip
+        Name of model use and model to get calculator.
+    system_id
+        Identifier of the system to run MD on.
+    """
+    assert system_id in range(0, N_SYSTEMS), (
+        f"system_id out of range. Please use a value from 0 to {N_SYSTEMS - 1}"
+    )
+
+    input_xyz_path = get_structure_paths()[system_id]
+
+    model_name, model = mlip
+    calc = model.get_calculator(precision="low")
+    if ADD_D3:
+        calc = model.add_d3_calculator(calc)
+
+    system_name = input_xyz_path.stem
+    out_dir = OUT_PATH / model_name
+    out_dir.mkdir(exist_ok=True, parents=True)
+
+    logging.basicConfig(
+        format="%(message)s",
+        level=logging.INFO,
+        filename=out_dir / f"{system_name}.log",
+        filemode="a",
+        force=True,
+    )
+
+    atoms = read(input_xyz_path)
+    output_fname = out_dir / f"{system_name}.traj"
+    run_npt(atoms, calc, output_fname)

--- a/ml_peg/calcs/molecular_dynamics/battery_electrolyte_densities/conftest.py
+++ b/ml_peg/calcs/molecular_dynamics/battery_electrolyte_densities/conftest.py
@@ -1,0 +1,35 @@
+"""Obtain the system_id input argument."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def pytest_addoption(parser):
+    """
+    Add pytest option.
+
+    Parameters
+    ----------
+    parser
+        Parser to use.
+    """
+    parser.addoption("--system-id", action="store", default=0, type=int)
+
+
+@pytest.fixture
+def system_id(request):
+    """
+    Get system_id argument.
+
+    Parameters
+    ----------
+    request
+        Request.
+
+    Returns
+    -------
+    option
+        Requested command line argument.
+    """
+    return request.config.getoption("--system-id")


### PR DESCRIPTION
## Pre-review checklist for PR author

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [x] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [x] I have added human-written tests for the new logic.
- [x] I have properly cited any upstream algorithms or libraries the AI utilized.
- [x] I have disclosed significant AI tool usage in the PR description.

## Summary

NPT density benchmark for 25 battery electrolyte systems, compared against experimental densities at 298.2 K. Six neat glyme and carbonate solvents (DME, DEGDME, TEGDME, PC, DEG, DMC) plus 19 electrolytes formed from NaPF6, NaOTf, NaTFSI and KPF6 at 0.1, 0.5 and 1.0 M. Systems range from roughly 500 to 2200 atoms.

Because the same salts recur across several solvents and concentrations, the benchmark separates general liquid-density performance from the harder question of whether a potential handles concentrated ionic environments.

Structures and reference densities are published at https://github.com/KMNitesh05/sodium-ion-battery-electrolyte-dataset, and the underlying paper is arXiv:2603.20183.

Protocol: NPT with the isotropic MTK barostat at 298.2 K and 1 atm, 1 fs timestep, 150 ps per system. The first 50 ps is discarded and the remaining 100 ps averaged. Metrics are MAE, RMSE and MAPE.

### Deliberate differences from `liquid_densities`

Four places where this diverges from the benchmark it is modelled on. All are one-line changes if you would rather I matched upstream:

1. **D3 is off** (`ADD_D3 = False`). The reference densities come from a dispersion-inclusive OMol25-trained potential, so a runtime D3 correction on top would double-count. One consequence worth flagging: the `-D3` display suffix from `build_dispersion_name_map` will be misleading for models not trained on dispersion. Happy to follow your preference on how that is handled.
2. **150 ps per system** rather than 1 ns, as described in #358. The inputs arrive already NPT-equilibrated with a potential of comparable quality, so the long re-equilibration is unnecessary.
3. **MAE and RMSE `bad` thresholds of 0.1 g/cm³** rather than 0.4. These densities span 0.861–1.291 g/cm³, so a 0.4 g/cm³ error is a 30–45% miss; at that scale the normalised score saturates near 1.0 for every model and stops discriminating.
4. **Densities are recomputed from the trajectory cells** rather than parsed out of the text log. The log format still matches `liquid_densities` field-for-field, so the log-parsing route remains available if you prefer consistency across the two benchmarks.

### AI tool usage

The code in this PR was drafted with AI assistance (Claude), using `liquid_densities` as the reference implementation, and reviewed by me before submission. The AI also generated the packaging script in the dataset repository that writes `exp_density` and `exp_temperature` into the extxyz headers.

No external algorithms were introduced. The MD driver is ASE's `IsotropicMTKNPT`, MAE and RMSE come from `ml_peg.analysis.utils.utils`, and the decorators/callbacks used are existing ML-PEG ones. `mape` is a five-line helper defined locally in the analysis module because `analysis/utils/utils.py` provides `mae` and `rmse` but not MAPE — happy to move it into the shared utils if you would prefer it there.

## Linked issue

Part of #358.

This PR delivers the 25 Na-ion systems only. The 23 Zn-ion systems also scoped in #358 belong to a dataset owned by ESRA whose paper is not yet published, so I have deliberately written "Part of" rather than "Resolves" to avoid auto-closing #358 on merge. The benchmark directory is named `battery_electrolyte_densities` so the Zn systems can be added later without a rename. Happy to split #358 into two issues instead if that is tidier.

Note also that #358 lists the category as Physicality, whereas this code sits under `molecular_dynamics` alongside `liquid_densities` and `water_density`. I think `molecular_dynamics` is the better home for an NPT density benchmark, but say the word and I will move it.

(#773 was a duplicate issue I opened by mistake and have now closed.)

## Progress

- [x] Calculations
- [x] Analysis
- [x] Application
- [x] Documentation

All four stages are implemented, but no production results exist yet — the benchmark has only been exercised with the `mock` model. The analysis and app stages are a first pass modelled closely on `liquid_densities`; @joehart2001 offered to help with those two, so please do take them over or rewrite as you see fit.

## Testing

Only the `mock` model so far. I do not yet have GPU allocation for 25 systems × N models, so I would welcome guidance on how you would like the production runs done.

Verified end to end against stand-in configurations constructed to match the dataset's cell vectors and reference densities exactly:

- reference densities written into the extxyz headers round-trip through `ase.io.read`
- `system_id` 0–24 resolves to the expected systems, and the count check catches a mismatched dataset
- velocity seeding produces a sensible temperature with zero net momentum, and is a no-op when momenta are already present
- MAE, RMSE and MAPE all recover ~0 from trajectories centred on the reference values
- MAPE returns exactly 10.0 for predictions uniformly 10% low, and propagates NaN rather than averaging a failed system away
- a trajectory shorter than the discarded equilibration window returns NaN rather than a misleading number
- the calc and analysis modules agree on the protocol arithmetic: 1500 frames written, first 500 discarded, 1000 averaged
- the metrics emitted by the analysis table exactly match the keys in `metrics.yml`
- `pre-commit run --all-files` is clean, including `numpydoc-validation`

The calc test is marked `very_slow`, so CI will not attempt the MD itself.

## New decorators/callbacks

None. This reuses `plot_parity`, `build_table`, `plot_from_table_column` and `struct_from_scatter` as they are. The parity plot uses the existing `symbol_by` argument to distinguish pure solvents from the 0.1, 0.5 and 1.0 M electrolytes.