### PR TITLE
⚡ Bolt: [performance improvement] Replace DataFrame.iterrows with faster iteration methods

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,6 @@
 ## 2024-05-19 - Caching YAML Load for Framework Registry
 **Learning:** `yaml.safe_load` on `frameworks.yml` within `load_framework_registry()` was taking ~2-3 ms per call and it was repeatedly called for every framework entry via `get_framework_config()`. This was a micro-bottleneck, especially when dealing with lists or multiple frameworks.
 **Action:** Applied the `@lru_cache` and `deepcopy` pattern successfully again to `load_framework_registry()` and `get_framework_config()` to avoid caching a mutable dictionary directly and avoid repeated YAML I/O parsing.
+## 2026-08-03 - Pandas DataFrame Iteration Optimization
+**Learning:** Iterating over Pandas DataFrames with `iterrows()` is a significant performance bottleneck. Replacing it with `itertuples()` or `to_dict('records')` provides much faster execution.
+**Action:** Use `to_dict('records')` for cases where column names might be invalid identifiers or dynamic dictionary access is needed, and `itertuples(index=False, name=None)` for fast static tuple-based row iteration.

--- a/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
+++ b/ml_peg/calcs/bulk_crystal/elasticity/calc_elasticity.py
@@ -301,7 +301,9 @@ def run_elasticity_benchmark(
         else {}
     )
     atoms_list = []
-    for _, row in results.iterrows():
+    for row in results.to_dict(
+        "records"
+    ):  # ⚡ Bolt: Use to_dict('records') over iterrows for faster iteration.
         struct = row.get("final_structure")
         if not isinstance(struct, Structure):
             struct = mock_ref_map.get(row[benchmark.index_name])

--- a/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
+++ b/ml_peg/calcs/conformers/MPCONF196/calc_MPCONF196.py
@@ -86,9 +86,11 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        ref_energies[label] = float(row[1][2]) * KCAL_TO_EV
+    for row in df.itertuples(
+        index=False, name=None
+    ):  # ⚡ Bolt: Use itertuples over iterrows for faster iteration.
+        label = row[0]
+        ref_energies[label] = float(row[2]) * KCAL_TO_EV
 
     return ref_energies
 

--- a/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
+++ b/ml_peg/calcs/conformers/solvMPCONF196/calc_solvMPCONF196.py
@@ -84,9 +84,11 @@ def get_ref_energies(data_path: Path) -> dict[str, float]:
     )
     ref_energies = {}
 
-    for row in df.iterrows():
-        label = row[1][0]
-        e_ref = float(row[1][1]) * units.Hartree
+    for row in df.itertuples(
+        index=False, name=None
+    ):  # ⚡ Bolt: Use itertuples over iterrows for faster iteration.
+        label = row[0]
+        e_ref = float(row[1]) * units.Hartree
         ref_energies[label] = e_ref
 
     return ref_energies

--- a/ml_peg/calcs/utils/gscdb138.py
+++ b/ml_peg/calcs/utils/gscdb138.py
@@ -106,7 +106,9 @@ def run_gscdb138(
         df_refs["Reference"] *= units.Hartree
 
         # Calculate relative energy for each entry.
-        for _, row in tqdm(df_refs.iterrows(), dataset, total=df_refs.shape[0]):
+        for row in tqdm(
+            df_refs.to_dict("records"), dataset, total=df_refs.shape[0]
+        ):  # ⚡ Bolt: Use to_dict('records') over iterrows for faster iteration.
             atoms_list = []
             identifier = row["Reaction"]
             reactions = row["Stoichiometry"].split(",")  # Parse stoichiometry string.


### PR DESCRIPTION
💡 What: Replaced `DataFrame.iterrows()` with `to_dict('records')` or `itertuples(index=False, name=None)`.
🎯 Why: `iterrows()` is a known bottleneck for Pandas dataframes.
📊 Impact: Significant reduction in iteration time for loops traversing dataframe records.
🔬 Measurement: The tests pass. The execution of these scripts will be faster.

---
*PR created automatically by Jules for task [18246168142508517079](https://jules.google.com/task/18246168142508517079) started by @alinelena*