### PR TITLE
Show Periodic Table for Oxygen Adsorption Benchmark

### DIFF
--- a/docs/source/user_guide/benchmarks/surfaces.rst
+++ b/docs/source/user_guide/benchmarks/surfaces.rst
@@ -152,7 +152,27 @@ Performance in predicting adsorption energies for oxygen on elemental slabs.
 Metrics
 -------
 
-Adsorption energy error
+1. MAE
+
+Mean absolute error of the adsorption energy, over all elements.
+
+2. U MAE
+
+Mean absolute error of the adsorption energy, over elements commonly given a Hubbard U
+correction in GGA+U training data, such as the Materials Project (Co, Cr, Fe, Mn, Mo,
+Ni, V and W). The reference calculations are PBE throughout, without a Hubbard U
+correction, so this metric isolates the error for elements where models trained on
+GGA+U data are expected to carry a systematic offset. Excluded from the benchmark
+score, since these systems are also included in the MAE.
+
+3. non-U MAE
+
+Mean absolute error of the adsorption energy, over the remaining elements. Excluded
+from the benchmark score, since these systems are also included in the MAE.
+
+Selecting a model shows a periodic table of its signed adsorption energy error
+(predicted - reference) for each element, and selecting an element visualises the
+corresponding slab with the adsorbed oxygen.
 
 For each slab, two single points are performed.
 The first is for the isolated slab and the second is the slab with

--- a/docs/source/user_guide/benchmarks/surfaces.rst
+++ b/docs/source/user_guide/benchmarks/surfaces.rst
@@ -47,7 +47,9 @@ Input data:
   * R. Tran, J. Lan, M. Shuaibi, B. M. Wood, S. Goyal, A. Das, J. Heras-Domingo, A. Kolluru, A. Rizvi, N. Shoghi, A. Sriram, F. Therrien, J. Abed, O. Voznyy, E. H. Sargent, Z. Ulissi, and C. L. Zitnick, “The Open Catalyst 2022 (OC22) data set and challenges for oxide electro catalysts,” ACS Catal., vol.13, pp. 3066–3084, Mar. 2023.
 
 * Structures containing oxygen (O) and several transition metals (Co, Cr, Fe, Mn, Mo,
-  Ni, V and W) were exlcuded due to Hubbard U correction
+  Ni, V and W) were excluded due to Hubbard U correction, as analysed in:
+
+  * T. Warford, F. L. Thiemann, G. Csányi, "Better without U: impact of selective Hubbard U correction on foundational MLIPs," Machine Learning: Science and Technology, 2026, 7:035033. https://doi.org/10.1088/2632-2153/ae6be5
 
 Reference data:
 
@@ -165,6 +167,8 @@ correction, so this metric isolates the error for elements where models trained 
 GGA+U data are expected to carry a systematic offset. Excluded from the benchmark
 score, since these systems are also included in the MAE.
 
+The choice of elements, and the systematic offset this metric isolates, follow Warford et al. (see Data availability).
+
 3. non-U MAE
 
 Mean absolute error of the adsorption energy, over the remaining elements. Excluded
@@ -172,7 +176,9 @@ from the benchmark score, since these systems are also included in the MAE.
 
 Selecting a model shows a periodic table of its signed adsorption energy error
 (predicted - reference) for each element, and selecting an element visualises the
-corresponding slab with the adsorbed oxygen. The table uses a symlog colormap.
+corresponding slab with the adsorbed oxygen. The periodic table uses a symlog
+colormap, so elements predicted well stay near the midpoint colour while the
+worst elements remain distinguishable from one another.
 
 For each slab, two single points are performed.
 The first is for the isolated slab and the second is the slab with
@@ -188,6 +194,10 @@ Very low: tests are likely to take less than a minute to run on CPU.
 Data availability
 -----------------
 
+The benchmark data is from:
+
+* T. Warford, F. L. Thiemann, G. Csányi, "Better without U: impact of selective Hubbard U correction on foundational MLIPs," Machine Learning: Science and Technology, 2026, 7:035033. https://doi.org/10.1088/2632-2153/ae6be5
+
 Input data:
 
 * Elemental slabs were obtained using the Materials Project API. The lowest-surface-energy slab
@@ -198,12 +208,10 @@ Input data:
 
 Reference data:
 
-* PBE single points are performed with the MatPESStatic set, with a cutoff energy of 520 eV.
+* PBE single points are performed with the MatPESStatic set, with a cutoff energy of 520 eV, using:
 
   * A. D. Kaplan, R. Liu, J. Qi, T. W. Ko, B. Deng, J. Riebesell, G. Ceder, K. A. Persson, S. P. Ong, "A Foundational Potential Energy Surface Dataset for Materials," arXiv preprint arXiv:2503.04070, 2025. https://doi.org/10.48550/arXiv.2503.04070
   * S. P. Ong, W. D. Richards, A. Jain, G. Hautier, M. Kocher, S. Cholia, D. Gunter, V. Chevrier, K. A. Persson, G. Ceder, "Python Materials Genomics (pymatgen): A Robust, Open-Source Python Library for Materials Analysis," Comput. Mater. Sci., 2013, 68, 314–319. https://doi.org/10.1016/j.commatsci.2012.10.028
-
-* Tran et al. relaxed the slabs using spin-polarized PBE calculations performed in VASP, with a cutoff energy of 400 eV.
 
 
 SBH17

--- a/docs/source/user_guide/benchmarks/surfaces.rst
+++ b/docs/source/user_guide/benchmarks/surfaces.rst
@@ -172,7 +172,7 @@ from the benchmark score, since these systems are also included in the MAE.
 
 Selecting a model shows a periodic table of its signed adsorption energy error
 (predicted - reference) for each element, and selecting an element visualises the
-corresponding slab with the adsorbed oxygen.
+corresponding slab with the adsorbed oxygen. The table uses a symlog colormap.
 
 For each slab, two single points are performed.
 The first is for the isolated slab and the second is the slab with

--- a/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
@@ -125,6 +125,20 @@ def periodic_tables(adsorption_energies: dict[str, list]) -> None:
         Dictionary of reference and predicted adsorption energies.
     """
     ref_energies = adsorption_energies["ref"]
+
+    # Share one colour scale across models, wide enough that no error is clipped
+    limit = max(
+        (
+            abs(pred - ref)
+            for model_name in MODELS
+            if adsorption_energies[model_name]
+            for pred, ref in zip(
+                adsorption_energies[model_name], ref_energies, strict=True
+            )
+        ),
+        default=DEFAULT_THRESHOLDS["MAE"]["bad"],
+    )
+
     ref_hover = {
         element: f"{energy:.3f}"
         for element, energy in zip(ELEMENTS, ref_energies, strict=True)
@@ -155,8 +169,11 @@ def periodic_tables(adsorption_energies: dict[str, list]) -> None:
                 OUT_PATH / model_name / "adsorption_error_periodic_table.json"
             ),
             colorscale="RdBu",
-            zmin=-DEFAULT_THRESHOLDS["MAE"]["bad"],
-            zmax=DEFAULT_THRESHOLDS["MAE"]["bad"],
+            zmin=-limit,
+            zmax=limit,
+            # Errors within the "good" threshold stay near the midpoint colour,
+            # so outliers remain distinguishable rather than saturating the scale
+            symlog_scale=DEFAULT_THRESHOLDS["MAE"]["good"],
         )(lambda values=errors: values)()
 
 

--- a/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
@@ -1,4 +1,10 @@
-"""Analyse elemental slab oxygen adsorption benchmark."""
+"""
+Analyse elemental slab oxygen adsorption benchmark.
+
+[1] Warford, Thomas, Fabian L. Thiemann, and Gábor Csányi. "Better without U: impact
+of selective Hubbard U correction on foundational MLIPs." Machine Learning: Science
+and Technology 7.3 (2026): 035033 (https://doi.org/10.1088/2632-2153/ae6be5).
+"""
 
 from __future__ import annotations
 
@@ -40,7 +46,8 @@ SYSTEM_INFO = get_struct_info(
 # Each slab is elemental, so frame 0 of each file has a single element
 ELEMENTS = [elements[0] for elements in SYSTEM_INFO["elements"]]
 
-# Transition metals commonly given a Hubbard U correction in GGA+U training data
+# Transition metals commonly given a Hubbard U correction in GGA+U training data,
+# as analysed in Warford et al. (https://doi.org/10.1088/2632-2153/ae6be5)
 U_ELEMENTS = frozenset({"Co", "Cr", "Fe", "Mn", "Mo", "Ni", "V", "W"})
 
 

--- a/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
@@ -8,7 +8,7 @@ from ase.io import read, write
 import numpy as np
 import pytest
 
-from ml_peg.analysis.utils.decorators import build_table, plot_parity
+from ml_peg.analysis.utils.decorators import build_table, plot_periodic_table
 from ml_peg.analysis.utils.utils import (
     get_struct_info,
     load_metrics_config,
@@ -37,6 +37,12 @@ SYSTEM_INFO = get_struct_info(
     out_path=OUT_PATH,
 )
 
+# Each slab is elemental, so frame 0 of each file has a single element
+ELEMENTS = [elements[0] for elements in SYSTEM_INFO["elements"]]
+
+# Transition metals commonly given a Hubbard U correction in GGA+U training data
+U_ELEMENTS = frozenset({"Co", "Cr", "Fe", "Mn", "Mo", "Ni", "V", "W"})
+
 
 def compute_adsorption_energy(
     surface_e: float, mol_surf_e: float, molecule_e: float
@@ -62,15 +68,6 @@ def compute_adsorption_energy(
 
 
 @pytest.fixture
-@plot_parity(
-    filename=OUT_PATH / "figure_adsorption_energies.json",
-    title="Adsorption energies",
-    x_label="Predicted adsorption energy / eV",
-    y_label="Reference adsorption energy / eV",
-    hoverdata={
-        "System": SYSTEM_INFO["filenames"],
-    },
-)
 def adsorption_energies() -> dict[str, list]:
     """
     Get adsorption energies for all systems.
@@ -118,7 +115,92 @@ def adsorption_energies() -> dict[str, list]:
 
 
 @pytest.fixture
-def adsorption_mae(adsorption_energies) -> dict[str, float]:
+def periodic_tables(adsorption_energies: dict[str, list]) -> None:
+    """
+    Write per-model periodic tables of adsorption energy errors.
+
+    Parameters
+    ----------
+    adsorption_energies
+        Dictionary of reference and predicted adsorption energies.
+    """
+    ref_energies = adsorption_energies["ref"]
+    ref_hover = {
+        element: f"{energy:.3f}"
+        for element, energy in zip(ELEMENTS, ref_energies, strict=True)
+    }
+
+    for model_name in MODELS:
+        pred_energies = adsorption_energies[model_name]
+        if not pred_energies:
+            continue
+
+        errors = {
+            element: pred - ref
+            for element, pred, ref in zip(
+                ELEMENTS, pred_energies, ref_energies, strict=True
+            )
+        }
+        plot_periodic_table(
+            title=f"Adsorption energy error - {model_name}",
+            colorbar_title="Error / eV",
+            hoverdata={
+                "Reference / eV": ref_hover,
+                "Predicted / eV": {
+                    element: f"{energy:.3f}"
+                    for element, energy in zip(ELEMENTS, pred_energies, strict=True)
+                },
+            },
+            filename=str(
+                OUT_PATH / model_name / "adsorption_error_periodic_table.json"
+            ),
+            colorscale="RdBu",
+            zmin=-DEFAULT_THRESHOLDS["MAE"]["bad"],
+            zmax=DEFAULT_THRESHOLDS["MAE"]["bad"],
+        )(lambda values=errors: values)()
+
+
+def _subset_mae(
+    adsorption_energies: dict[str, list], elements: set[str] | None = None
+) -> dict[str, float]:
+    """
+    Get mean absolute error for adsorption energies of selected elements.
+
+    Parameters
+    ----------
+    adsorption_energies
+        Dictionary of reference and predicted adsorption energies.
+    elements
+        Elements to include. Default is `None`, corresponding to all elements.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary of predicted adsorption energy errors for all models.
+    """
+    mask = [elements is None or element in elements for element in ELEMENTS]
+    refs = [
+        energy
+        for energy, keep in zip(adsorption_energies["ref"], mask, strict=True)
+        if keep
+    ]
+
+    results = {}
+    for model_name in MODELS:
+        if not adsorption_energies[model_name]:
+            results[model_name] = np.nan
+            continue
+        preds = [
+            energy
+            for energy, keep in zip(adsorption_energies[model_name], mask, strict=True)
+            if keep
+        ]
+        results[model_name] = mae(refs, preds) if preds else np.nan
+    return results
+
+
+@pytest.fixture
+def adsorption_mae(adsorption_energies: dict[str, list]) -> dict[str, float]:
     """
     Get mean absolute error for adsorption energies.
 
@@ -132,15 +214,43 @@ def adsorption_mae(adsorption_energies) -> dict[str, float]:
     dict[str, float]
         Dictionary of predicted adsorption energy errors for all models.
     """
-    results = {}
-    for model_name in MODELS:
-        if adsorption_energies[model_name]:
-            results[model_name] = mae(
-                adsorption_energies["ref"], adsorption_energies[model_name]
-            )
-        else:
-            results[model_name] = np.nan
-    return results
+    return _subset_mae(adsorption_energies)
+
+
+@pytest.fixture
+def adsorption_mae_u(adsorption_energies: dict[str, list]) -> dict[str, float]:
+    """
+    Get mean absolute error for adsorption energies of Hubbard U elements.
+
+    Parameters
+    ----------
+    adsorption_energies
+        Dictionary of reference and predicted adsorption energies.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary of predicted adsorption energy errors for all models.
+    """
+    return _subset_mae(adsorption_energies, U_ELEMENTS)
+
+
+@pytest.fixture
+def adsorption_mae_non_u(adsorption_energies: dict[str, list]) -> dict[str, float]:
+    """
+    Get mean absolute error for adsorption energies of non-Hubbard U elements.
+
+    Parameters
+    ----------
+    adsorption_energies
+        Dictionary of reference and predicted adsorption energies.
+
+    Returns
+    -------
+    dict[str, float]
+        Dictionary of predicted adsorption energy errors for all models.
+    """
+    return _subset_mae(adsorption_energies, set(ELEMENTS) - U_ELEMENTS)
 
 
 @pytest.fixture
@@ -148,8 +258,13 @@ def adsorption_mae(adsorption_energies) -> dict[str, float]:
     filename=OUT_PATH / "elemental_slab_oxygen_adsorption_metrics_table.json",
     metric_tooltips=DEFAULT_TOOLTIPS,
     thresholds=DEFAULT_THRESHOLDS,
+    weights=DEFAULT_WEIGHTS,
 )
-def metrics(adsorption_mae: dict[str, float]) -> dict[str, dict]:
+def metrics(
+    adsorption_mae: dict[str, float],
+    adsorption_mae_u: dict[str, float],
+    adsorption_mae_non_u: dict[str, float],
+) -> dict[str, dict]:
     """
     Get all metrics.
 
@@ -157,6 +272,10 @@ def metrics(adsorption_mae: dict[str, float]) -> dict[str, dict]:
     ----------
     adsorption_mae
         Mean absolute errors for all models.
+    adsorption_mae_u
+        Mean absolute errors for Hubbard U elements, for all models.
+    adsorption_mae_non_u
+        Mean absolute errors for non-Hubbard U elements, for all models.
 
     Returns
     -------
@@ -165,10 +284,14 @@ def metrics(adsorption_mae: dict[str, float]) -> dict[str, dict]:
     """
     return {
         "MAE": adsorption_mae,
+        "U MAE": adsorption_mae_u,
+        "non-U MAE": adsorption_mae_non_u,
     }
 
 
-def test_elemental_slab_oxygen_adsorption(metrics: dict[str, dict]) -> None:
+def test_elemental_slab_oxygen_adsorption(
+    metrics: dict[str, dict], periodic_tables: None
+) -> None:
     """
     Run elemental_slab_oxygen_adsorption test.
 
@@ -176,5 +299,7 @@ def test_elemental_slab_oxygen_adsorption(metrics: dict[str, dict]) -> None:
     ----------
     metrics
         All elemental slab oxygen adsorption metrics.
+    periodic_tables
+        Per-model periodic-table heatmaps (side-effect only).
     """
     return

--- a/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/analyse_elemental_slab_oxygen_adsorption.py
@@ -126,16 +126,20 @@ def periodic_tables(adsorption_energies: dict[str, list]) -> None:
     """
     ref_energies = adsorption_energies["ref"]
 
+    model_errors = {
+        model_name: {
+            element: pred - ref
+            for element, pred, ref in zip(
+                ELEMENTS, pred_energies, ref_energies, strict=True
+            )
+        }
+        for model_name in MODELS
+        if (pred_energies := adsorption_energies[model_name])
+    }
+
     # Share one colour scale across models, wide enough that no error is clipped
     limit = max(
-        (
-            abs(pred - ref)
-            for model_name in MODELS
-            if adsorption_energies[model_name]
-            for pred, ref in zip(
-                adsorption_energies[model_name], ref_energies, strict=True
-            )
-        ),
+        (abs(error) for errors in model_errors.values() for error in errors.values()),
         default=DEFAULT_THRESHOLDS["MAE"]["bad"],
     )
 
@@ -144,25 +148,22 @@ def periodic_tables(adsorption_energies: dict[str, list]) -> None:
         for element, energy in zip(ELEMENTS, ref_energies, strict=True)
     }
 
-    for model_name in MODELS:
-        pred_energies = adsorption_energies[model_name]
-        if not pred_energies:
-            continue
+    scale_note = (
+        "<br><sub>Symmetric log colour scale, near-linear within "
+        f"\u00b1{DEFAULT_THRESHOLDS['MAE']['good']:g} eV</sub>"
+    )
 
-        errors = {
-            element: pred - ref
-            for element, pred, ref in zip(
-                ELEMENTS, pred_energies, ref_energies, strict=True
-            )
-        }
+    for model_name, errors in model_errors.items():
         plot_periodic_table(
-            title=f"Adsorption energy error - {model_name}",
+            title=f"Adsorption energy error - {model_name}{scale_note}",
             colorbar_title="Error / eV",
             hoverdata={
                 "Reference / eV": ref_hover,
                 "Predicted / eV": {
                     element: f"{energy:.3f}"
-                    for element, energy in zip(ELEMENTS, pred_energies, strict=True)
+                    for element, energy in zip(
+                        ELEMENTS, adsorption_energies[model_name], strict=True
+                    )
                 },
             },
             filename=str(

--- a/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/metrics.yml
+++ b/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/metrics.yml
@@ -13,7 +13,8 @@ metrics:
     tooltip: >-
       Mean Absolute Error for elements commonly given a Hubbard U correction in
       GGA+U training data, such as the Materials Project (Co, Cr, Fe, Mn, Mo, Ni,
-      V and W). The reference calculations are PBE, without a Hubbard U correction
+      V and W). The reference calculations are PBE, without a Hubbard U correction.
+      See Warford et al. (https://doi.org/10.1088/2632-2153/ae6be5)
     level_of_theory: PBE
   non-U MAE:
     good: 0.1

--- a/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/metrics.yml
+++ b/ml_peg/analysis/surfaces/elemental_slab_oxygen_adsorption/metrics.yml
@@ -5,3 +5,22 @@ metrics:
     unit: eV
     tooltip: Mean Absolute Error
     level_of_theory: PBE
+  U MAE:
+    good: 0.1
+    bad: 2.0
+    unit: eV
+    weight: 0
+    tooltip: >-
+      Mean Absolute Error for elements commonly given a Hubbard U correction in
+      GGA+U training data, such as the Materials Project (Co, Cr, Fe, Mn, Mo, Ni,
+      V and W). The reference calculations are PBE, without a Hubbard U correction
+    level_of_theory: PBE
+  non-U MAE:
+    good: 0.1
+    bad: 2.0
+    unit: eV
+    weight: 0
+    tooltip: >-
+      Mean Absolute Error for the remaining elements, which are not commonly given
+      a Hubbard U correction in GGA+U training data
+    level_of_theory: PBE

--- a/ml_peg/analysis/utils/decorators.py
+++ b/ml_peg/analysis/utils/decorators.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from dash import dash_table
+from matplotlib.ticker import SymmetricalLogLocator
 import numpy as np
 import pandas as pd
 import plotly.colors as pc
@@ -26,6 +27,7 @@ from ml_peg.analysis.utils.utils import (
     DENSITY_SAMPLE_SEED,
     calc_table_scores,
     sample_density_grid,
+    symlog_transform,
 )
 from ml_peg.app.utils.utils import Thresholds
 from ml_peg.models.get_models import get_model_names, load_model_configs
@@ -1092,59 +1094,6 @@ def plot_violin(
     return plot_violin_decorator
 
 
-def symlog_transform(values: np.ndarray, scale: float) -> np.ndarray:
-    """
-    Apply a symmetric logarithmic transform, preserving sign.
-
-    Values well within ``scale`` are mapped near-linearly, while larger magnitudes
-    are compressed logarithmically. This keeps small and large errors legible on a
-    single colour scale, rather than saturating the scale with outliers.
-
-    Parameters
-    ----------
-    values
-        Values to transform.
-    scale
-        Magnitude below which the transform is approximately linear. Typically the
-        "good" threshold for the metric, so values scoring as good stay near zero.
-
-    Returns
-    -------
-    np.ndarray
-        Transformed values.
-    """
-    return np.sign(values) * np.log10(1 + np.abs(values) / scale)
-
-
-def symlog_ticks(scale: float, limit: float) -> list[float]:
-    """
-    Get symmetric tick values for a symlog colour bar, in untransformed units.
-
-    Ticks follow a 1-3-10 progression from `scale` up to `limit`, mirrored about
-    zero, so each decade of the colour bar is labelled.
-
-    Parameters
-    ----------
-    scale
-        Magnitude below which the symlog transform is approximately linear.
-    limit
-        Largest magnitude to label.
-
-    Returns
-    -------
-    list[float]
-        Tick values, in ascending order.
-    """
-    ticks = []
-    step = scale
-    while step <= limit:
-        ticks.extend((step, 3 * step))
-        step *= 10
-
-    ticks = [tick for tick in ticks if tick <= limit]
-    return sorted({-tick for tick in ticks} | {0.0} | set(ticks))
-
-
 def plot_periodic_table(
     title: str | None = None,
     colorbar_title: str | None = None,
@@ -1177,8 +1126,8 @@ def plot_periodic_table(
         setting the width of the near-linear region about zero. Typically the "good"
         threshold for the metric, so values scoring as good stay near the midpoint,
         while outliers remain distinguishable instead of saturating the scale.
-        The colour bar is labelled in the original units, and the scale is noted
-        beneath the title. Default is `None`, corresponding to a linear scale.
+        The colour bar is labelled in the original units. Default is `None`,
+        corresponding to a linear scale.
 
     Returns
     -------
@@ -1247,37 +1196,31 @@ def plot_periodic_table(
 
             colorbar = {"title": colorbar_title}
             plot_min, plot_max = zmin, zmax
-            heading = title
             if symlog_scale is not None:
                 if symlog_scale <= 0:
                     raise ValueError("`symlog_scale` must be positive")
 
-                limit = max(
-                    abs(value)
-                    for value in (zmin, zmax, np.nanmin(grid), np.nanmax(grid))
-                    if value is not None
-                )
-                ticks = symlog_ticks(symlog_scale, limit)
-                colorbar |= {
-                    "tickvals": symlog_transform(np.array(ticks), symlog_scale),
-                    "ticktext": [f"{tick:g}" for tick in ticks],
-                }
+                if plot_min is None or plot_max is None:
+                    data_limit = np.nanmax(np.abs(grid))
+                    plot_min = -data_limit if plot_min is None else plot_min
+                    plot_max = data_limit if plot_max is None else plot_max
 
-                if heading:
-                    heading += (
-                        "<br><sub>Symmetric log colour scale, near-linear within "
-                        f"\u00b1{symlog_scale:g}</sub>"
-                    )
+                # Label each decade of the colour bar, within the plotted range
+                limit = max(abs(plot_min), abs(plot_max))
+                locator = SymmetricalLogLocator(
+                    linthresh=symlog_scale, base=10, subs=[1.0, 3.0]
+                )
+                ticks = sorted(
+                    tick
+                    for tick in locator.tick_values(-limit, limit)
+                    if abs(tick) <= limit
+                )
+                colorbar["tickvals"] = symlog_transform(np.array(ticks), symlog_scale)
+                colorbar["ticktext"] = [f"{tick:g}" for tick in ticks]
 
                 grid = symlog_transform(grid, symlog_scale)
                 plot_min, plot_max = symlog_transform(
-                    np.array(
-                        [
-                            -limit if zmin is None else zmin,
-                            limit if zmax is None else zmax,
-                        ]
-                    ),
-                    symlog_scale,
+                    np.array([plot_min, plot_max]), symlog_scale
                 )
 
             fig = go.Figure(
@@ -1314,7 +1257,7 @@ def plot_periodic_table(
             )
 
             fig.update_layout(
-                title={"text": heading},
+                title={"text": title},
                 xaxis={
                     "visible": False,
                     "range": [-0.5, PERIODIC_TABLE_COLS - 0.5],

--- a/ml_peg/analysis/utils/decorators.py
+++ b/ml_peg/analysis/utils/decorators.py
@@ -1092,6 +1092,59 @@ def plot_violin(
     return plot_violin_decorator
 
 
+def symlog_transform(values: np.ndarray, scale: float) -> np.ndarray:
+    """
+    Apply a symmetric logarithmic transform, preserving sign.
+
+    Values well within ``scale`` are mapped near-linearly, while larger magnitudes
+    are compressed logarithmically. This keeps small and large errors legible on a
+    single colour scale, rather than saturating the scale with outliers.
+
+    Parameters
+    ----------
+    values
+        Values to transform.
+    scale
+        Magnitude below which the transform is approximately linear. Typically the
+        "good" threshold for the metric, so values scoring as good stay near zero.
+
+    Returns
+    -------
+    np.ndarray
+        Transformed values.
+    """
+    return np.sign(values) * np.log10(1 + np.abs(values) / scale)
+
+
+def symlog_ticks(scale: float, limit: float) -> list[float]:
+    """
+    Get symmetric tick values for a symlog colour bar, in untransformed units.
+
+    Ticks follow a 1-3-10 progression from `scale` up to `limit`, mirrored about
+    zero, so each decade of the colour bar is labelled.
+
+    Parameters
+    ----------
+    scale
+        Magnitude below which the symlog transform is approximately linear.
+    limit
+        Largest magnitude to label.
+
+    Returns
+    -------
+    list[float]
+        Tick values, in ascending order.
+    """
+    ticks = []
+    step = scale
+    while step <= limit:
+        ticks.extend((step, 3 * step))
+        step *= 10
+
+    ticks = [tick for tick in ticks if tick <= limit]
+    return sorted({-tick for tick in ticks} | {0.0} | set(ticks))
+
+
 def plot_periodic_table(
     title: str | None = None,
     colorbar_title: str | None = None,
@@ -1100,6 +1153,7 @@ def plot_periodic_table(
     colorscale: str = "Viridis",
     zmin: float | None = None,
     zmax: float | None = None,
+    symlog_scale: float | None = None,
 ) -> Callable:
     """
     Plot a periodic-table heatmap for element-wise metrics.
@@ -1118,6 +1172,13 @@ def plot_periodic_table(
         Plotly colourscale name. Default is ``"Viridis"``.
     zmin, zmax
         Optional colour scale limits. If not provided, they are inferred from the data.
+    symlog_scale
+        If set, colours are mapped symmetrically logarithmically, with this magnitude
+        setting the width of the near-linear region about zero. Typically the "good"
+        threshold for the metric, so values scoring as good stay near the midpoint,
+        while outliers remain distinguishable instead of saturating the scale.
+        The colour bar is labelled in the original units. Default is `None`,
+        corresponding to a linear scale.
 
     Returns
     -------
@@ -1184,6 +1245,41 @@ def plot_periodic_table(
                 hover_grid[row, col] = "<br>".join(hover_parts)
                 text_grid[row, col] = element
 
+            colorbar = {"title": colorbar_title}
+            plot_min, plot_max = zmin, zmax
+            heading = title
+            if symlog_scale is not None:
+                if symlog_scale <= 0:
+                    raise ValueError("`symlog_scale` must be positive")
+
+                limit = max(
+                    abs(value)
+                    for value in (zmin, zmax, np.nanmin(grid), np.nanmax(grid))
+                    if value is not None
+                )
+                ticks = symlog_ticks(symlog_scale, limit)
+                colorbar |= {
+                    "tickvals": symlog_transform(np.array(ticks), symlog_scale),
+                    "ticktext": [f"{tick:g}" for tick in ticks],
+                }
+
+                if heading:
+                    heading += (
+                        "<br><sub>Symmetric log colour scale, near-linear within "
+                        f"\u00b1{symlog_scale:g}</sub>"
+                    )
+
+                grid = symlog_transform(grid, symlog_scale)
+                plot_min, plot_max = symlog_transform(
+                    np.array(
+                        [
+                            -limit if zmin is None else zmin,
+                            limit if zmax is None else zmax,
+                        ]
+                    ),
+                    symlog_scale,
+                )
+
             fig = go.Figure(
                 data=go.Heatmap(
                     z=grid,
@@ -1192,10 +1288,10 @@ def plot_periodic_table(
                     text=hover_grid,
                     hovertemplate="%{text}<extra></extra>",
                     colorscale=colorscale,
-                    colorbar={"title": colorbar_title},
+                    colorbar=colorbar,
                     showscale=True,
-                    zmin=zmin,
-                    zmax=zmax,
+                    zmin=plot_min,
+                    zmax=plot_max,
                 )
             )
 
@@ -1218,7 +1314,7 @@ def plot_periodic_table(
             )
 
             fig.update_layout(
-                title={"text": title},
+                title={"text": heading},
                 xaxis={
                     "visible": False,
                     "range": [-0.5, PERIODIC_TABLE_COLS - 0.5],

--- a/ml_peg/analysis/utils/decorators.py
+++ b/ml_peg/analysis/utils/decorators.py
@@ -1177,8 +1177,8 @@ def plot_periodic_table(
         setting the width of the near-linear region about zero. Typically the "good"
         threshold for the metric, so values scoring as good stay near the midpoint,
         while outliers remain distinguishable instead of saturating the scale.
-        The colour bar is labelled in the original units. Default is `None`,
-        corresponding to a linear scale.
+        The colour bar is labelled in the original units, and the scale is noted
+        beneath the title. Default is `None`, corresponding to a linear scale.
 
     Returns
     -------

--- a/ml_peg/analysis/utils/utils.py
+++ b/ml_peg/analysis/utils/utils.py
@@ -192,6 +192,30 @@ DENSITY_MAX_POINTS_PER_CELL = 5
 DENSITY_SAMPLE_SEED = 0
 
 
+def symlog_transform(values: np.ndarray, scale: float) -> np.ndarray:
+    """
+    Apply a symmetric logarithmic transform, preserving sign.
+
+    Values well within ``scale`` are mapped near-linearly, while larger magnitudes
+    are compressed logarithmically. This keeps small and large values legible on a
+    single colour scale, rather than saturating the scale with outliers.
+
+    Parameters
+    ----------
+    values
+        Values to transform.
+    scale
+        Magnitude below which the transform is approximately linear. Typically the
+        "good" threshold for the metric, so values scoring as good stay near zero.
+
+    Returns
+    -------
+    np.ndarray
+        Transformed values.
+    """
+    return np.sign(values) * np.log10(1 + np.abs(values) / scale)
+
+
 def sample_density_grid(
     ref_vals: list[float] | np.ndarray,
     pred_vals: list[float] | np.ndarray,

--- a/ml_peg/app/surfaces/elemental_slab_oxygen_adsorption/app_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/app/surfaces/elemental_slab_oxygen_adsorption/app_elemental_slab_oxygen_adsorption.py
@@ -2,15 +2,18 @@
 
 from __future__ import annotations
 
-from dash.html import Div
+import re
+
+from dash import ALL, Input, Output, callback, callback_context
+from dash.dcc import Graph
+from dash.exceptions import PreventUpdate
+from dash.html import Div, Iframe
+from plotly.io import read_json
 
 from ml_peg.app import APP_ROOT
 from ml_peg.app.base_app import BaseApp
-from ml_peg.app.utils.build_callbacks import (
-    plot_from_table_column,
-    struct_from_scatter,
-)
-from ml_peg.app.utils.load import read_plot
+from ml_peg.app.utils.build_callbacks import plot_from_table_cell
+from ml_peg.app.utils.weas import generate_weas_html
 from ml_peg.models import current_models
 from ml_peg.models.get_models import get_model_names
 
@@ -20,6 +23,9 @@ BENCHMARK_NAME = "Elemental Slab Oxygen Adsorption"
 DOCS_URL = "https://ddmms.github.io/ml-peg/user_guide/benchmarks/surfaces.html#elemental-slab-oxygen-adsorption"
 DATA_PATH = APP_ROOT / "data" / "surfaces" / "elemental_slab_oxygen_adsorption"
 INFO_PATH = DATA_PATH / "info.json"
+PT_TYPE = "oxygen-adsorption-periodic-table"
+METRIC_COLUMNS = ("MAE", "U MAE", "non-U MAE")
+STRUCT_ID = f"{BENCHMARK_NAME}-struct-placeholder"
 
 
 class ElementalSlabOxygenAdsorptionApp(BaseApp):
@@ -27,31 +33,82 @@ class ElementalSlabOxygenAdsorptionApp(BaseApp):
 
     def register_callbacks(self) -> None:
         """Register callbacks to app."""
-        scatter = read_plot(
-            DATA_PATH / "figure_adsorption_energies.json",
-            id=f"{BENCHMARK_NAME}-figure",
-        )
+        cell_to_plot = {}
+        for model in MODELS:
+            path = DATA_PATH / model / "adsorption_error_periodic_table.json"
+            if not path.exists():
+                continue
+            graph = Graph(
+                id={"type": PT_TYPE, "model": model},
+                figure=read_json(path),
+            )
+            cell_to_plot[model] = dict.fromkeys(METRIC_COLUMNS, graph)
 
-        structs_dir = DATA_PATH / MODELS[0]
-
-        # Assets dir will be parent directory
-        structs = [
-            f"/assets/surfaces/elemental_slab_oxygen_adsorption/{MODELS[0]}/{struct_file.stem}.xyz"
-            for struct_file in sorted(structs_dir.glob("*.xyz"))
-        ]
-
-        plot_from_table_column(
+        plot_from_table_cell(
             table_id=self.table_id,
             plot_id=f"{BENCHMARK_NAME}-figure-placeholder",
-            column_to_plot={"MAE": scatter},
+            cell_to_plot=cell_to_plot,
         )
 
-        struct_from_scatter(
-            scatter_id=f"{BENCHMARK_NAME}-figure",
-            struct_id=f"{BENCHMARK_NAME}-struct-placeholder",
-            structs=structs,
-            mode="traj",
+        # Map each element to its structure file, e.g. "Fe" -> "Fe54-O.xyz"
+        element_to_struct = {}
+        for struct_file in sorted((DATA_PATH / MODELS[0]).glob("*.xyz")):
+            match = re.match(r"([A-Z][a-z]?)\d", struct_file.stem)
+            if match:
+                element_to_struct[match.group(1)] = struct_file.name
+
+        @callback(
+            Output(STRUCT_ID, "children"),
+            Input({"type": PT_TYPE, "model": ALL}, "clickData"),
+            prevent_initial_call=True,
         )
+        def show_struct(_):
+            """
+            Show the slab and adsorbed oxygen for the clicked element and model.
+
+            Parameters
+            ----------
+            _
+                Click data from the periodic table graph. The callback context is
+                used instead, to determine which model's table was clicked.
+
+            Returns
+            -------
+            Div
+                Visualised structure on element click.
+            """
+            ctx = callback_context
+            triggered_id = ctx.triggered_id
+            if not isinstance(triggered_id, dict):
+                raise PreventUpdate
+            click_data = ctx.triggered[0]["value"]
+            if not click_data:
+                raise PreventUpdate
+            points = click_data.get("points", [])
+            if not points:
+                raise PreventUpdate
+
+            element = points[0].get("text", "").split("<br>")[0].strip()
+            struct_file = element_to_struct.get(element)
+            model = triggered_id["model"]
+            if not struct_file:
+                return Div(f"No structure for {element}.")
+
+            struct = (
+                "/assets/surfaces/elemental_slab_oxygen_adsorption/"
+                f"{model}/{struct_file}"
+            )
+            return Div(
+                Iframe(
+                    srcDoc=generate_weas_html(struct),
+                    style={
+                        "height": "550px",
+                        "width": "100%",
+                        "border": "1px solid #ddd",
+                        "borderRadius": "5px",
+                    },
+                )
+            )
 
 
 def get_app() -> ElementalSlabOxygenAdsorptionApp:
@@ -73,7 +130,7 @@ def get_app() -> ElementalSlabOxygenAdsorptionApp:
         table_path=DATA_PATH / "elemental_slab_oxygen_adsorption_metrics_table.json",
         extra_components=[
             Div(id=f"{BENCHMARK_NAME}-figure-placeholder"),
-            Div(id=f"{BENCHMARK_NAME}-struct-placeholder"),
+            Div(id=STRUCT_ID),
         ],
         info_path=INFO_PATH,
     )

--- a/ml_peg/calcs/surfaces/elemental_slab_oxygen_adsorption/calc_elemental_slab_oxygen_adsorption.py
+++ b/ml_peg/calcs/surfaces/elemental_slab_oxygen_adsorption/calc_elemental_slab_oxygen_adsorption.py
@@ -44,9 +44,9 @@ class ElementalSlabOxygenAdsorptionBenchmark(zntrack.Node):
     The adsorption energy (E(molecule+surface) - E(surface) - E(molecule)) is calculated
     for elements.
 
-    The reference energies are calculated using `pymatgen.io.vasp.sets.MatPESStaticSet`,
-    with `user_incar_setting`. The following modifications to the default settings are
-    made.
+    The reference energies were calculated by Warford et al. [2], using
+    `pymatgen.io.vasp.sets.MatPESStaticSet`, with `user_incar_setting`. The following
+    modifications to the default settings are made.
 
     {
     "ENCUT", 520
@@ -58,6 +58,11 @@ class ElementalSlabOxygenAdsorptionBenchmark(zntrack.Node):
 
     [1] Tran, Richard, et al. "Surface energies of elemental crystals." Scientific data
     3.1 (2016): 1-13 (https://doi.org/10.1038/sdata.2016.80).
+
+    [2] Warford, Thomas, Fabian L. Thiemann, and Gábor Csányi. "Better without U:
+    impact of selective Hubbard U correction on foundational MLIPs." Machine Learning:
+    Science and Technology 7.3 (2026): 035033
+    (https://doi.org/10.1088/2632-2153/ae6be5).
     """
 
     model: NodeWithCalculator = zntrack.deps()


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [x] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [ ] I have added human-written tests for the new logic.
- [x] I have properly cited any upstream algorithms or libraries the AI utilized.
- [x] I have disclosed significant AI tool usage in the PR description.

## Summary
- Add two columns U MAE and no-U MAE to the app. This makes it easy to see whether a model is failing across the board or on elements have have +U applied in the training data.
- Clicking on a cell now brings up a periodic table, showing the adsorption error. Clicking on an element shows the relevant structure.
- A "symlog" colormap has been added to the periodic table plot only, to make it easier to view differences between "bad" elements. This can be reverted if desired! [dc6bf47](https://github.com/ddmms/ml-peg/pull/824/commits/dc6bf4706ef4bb70680b424a28b9b1a9d3386a37)
- Changes made with claude. I have read the code and docs.
## Linked issue

Resolves #823

## Testing

None, can add for "symlog" scale in periodic table plot if desired. Or we can revert the symlog commits.
