### PR TITLE
Fix table sorting with NaN

### DIFF
--- a/ml_peg/app/utils/build_components.py
+++ b/ml_peg/app/utils/build_components.py
@@ -266,6 +266,7 @@ def build_summary_table(
         id=table_id,
         markdown_options={"link_target": "_blank"},
         sort_action="native",
+        sort_as_null=["NaN"],
         style_data_conditional=style_with_warnings,
         style_cell_conditional=style_cell_conditional,
         style_header={

--- a/ml_peg/app/utils/load.py
+++ b/ml_peg/app/utils/load.py
@@ -209,6 +209,7 @@ def rebuild_table(
             }
         ],
         sort_action="native",
+        sort_as_null=["NaN"],
         fill_width=False,
     )
 


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [x] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [x] I have added human-written tests for the new logic.
- [x] I have properly cited any upstream algorithms or libraries the AI utilized.
- [x] I have disclosed significant AI tool usage in the PR description.

## Summary

Currently sorting tables does not work consistently, due to "NaN" string values being handled inconsistently vs floats. This tells the table that these are equivalent to 'null' for sorting purposes, which fixes this.

## Testing

Tested locally
