### PR TITLE
Split vacancy initial structures

### DIFF
--- a/docs/source/user_guide/benchmarks/defects.rst
+++ b/docs/source/user_guide/benchmarks/defects.rst
@@ -230,8 +230,8 @@ Summary
 -------
 
 Performance predicting split vacancy formation energies and relaxed structures for
-metal oxides (PBEsol, 531 host compounds, 722 material-cation pairs, 2154 structures)
-and stable nitrides (PBE, 144 host compounds, 149 material-cation pairs, 285 structures).
+metal oxides (PBEsol, 344 host compounds, 420 material-cation pairs, 1514 structures)
+and stable nitrides (PBE, 57 host compounds, 58 material-cation pairs, 144 structures).
 
 A split vacancy is a stoichiometry-conserving defect complex in which an isolated atomic
 vacancy reconstructs into two vacancies and an interstitial
@@ -241,6 +241,9 @@ Data from Seán Kavanagh, *Identifying split vacancy defects with machine-learne
 `https://doi.org/10.1088/2515-7655/ade916 <https://doi.org/10.1088/2515-7655/ade916>`_
 
 **Note that oxide calculations were performed with PBEsol, whilst nitride calculations were performed with PBE.**
+
+MLIP relaxations start from the *initial*, unrelaxed point-vacancy/split-vacancy
+structure (regenerated directly from the bulk supercell).
 
 Metrics
 -------
@@ -255,7 +258,7 @@ structures:
 
    E_\text{form} = \min_i E^\text{SV}_i - \min_j E^\text{NV}_j
 
-where the minima are taken over all initial structures that match the DFT reference
+where the minima are taken over all MLIP-relaxed structures that match the DFT reference
 (see metric 3) for a given material-cation pair.
 
 2. Spearman's rank correlation
@@ -286,7 +289,9 @@ Computational cost
 ------------------
 
 Relatively slow: relaxations involve large defect supercells (50–500 atoms) and
-multiple initial structures per material-cation pair.
+multiple initial structures per material-cation pair. On a single NVIDIA A100
+GPU, a full run (both PBE and PBEsol subsets) takes roughly 2-2.5 hours per
+MACE model.
 
 
 Data availability
@@ -296,8 +301,11 @@ Input structures:
 
 * Generated using the `doped <https://github.com/SMTG-Bham/doped>`_ supercell
   algorithm. For oxides, supercell parameters are consistent with those of
-  Kumagai et al. (using the ``vise`` package). Supercells satisfy a minimum image
-  distance of 10 Å and a minimum of 50 atoms.
+  Kumagai et al. (using the ``vise`` package): Y. Kumagai, N. Tsunoda, A. Takahashi,
+  F. Oba, *Insights into Oxygen Vacancies from High-Throughput First-Principles
+  Calculations*, Phys. Rev. Materials 5, 123803 (2021),
+  `https://doi.org/10.1103/PhysRevMaterials.5.123803 <https://doi.org/10.1103/PhysRevMaterials.5.123803>`_.
+  Supercells satisfy a minimum image distance of 10 Å and a minimum of 50 atoms.
 
 Reference data:
 

--- a/ml_peg/analysis/defects/split_vacancy/analyse_split_vacancy.py
+++ b/ml_peg/analysis/defects/split_vacancy/analyse_split_vacancy.py
@@ -249,6 +249,7 @@ def build_results(
 
             nv_initial_energies = []
             nv_relaxed_energies = []
+            nv_ref_structure_mlip_energies = []
             for nv_atoms in nv_atoms_list:
                 match = nv_atoms.info["ref_max_distance"] < STOL
                 match_list.append(match)
@@ -258,9 +259,13 @@ def build_results(
                 rmsd_list.append(nv_atoms.info["ref_rmsd"])
                 max_dist_list.append(nv_atoms.info["ref_max_distance"])
                 nv_initial_energies.append(nv_atoms.info["initial_energy"])
+                nv_ref_structure_mlip_energies.append(
+                    nv_atoms.info["ref_structure_mlip_energy"]
+                )
 
             sv_initial_energies = []
             sv_relaxed_energies = []
+            sv_ref_structure_mlip_energies = []
             for sv_atoms in sv_atoms_list:
                 match = sv_atoms.info["ref_max_distance"] < STOL
                 match_list.append(match)
@@ -270,12 +275,18 @@ def build_results(
                 rmsd_list.append(sv_atoms.info["ref_rmsd"])
                 max_dist_list.append(sv_atoms.info["ref_max_distance"])
                 sv_initial_energies.append(sv_atoms.info["initial_energy"])
+                sv_ref_structure_mlip_energies.append(
+                    sv_atoms.info["ref_structure_mlip_energy"]
+                )
 
             sv_formation_energy = min(sv_relaxed_energies, default=np.nan) - min(
                 nv_relaxed_energies, default=np.nan
             )
+            # ranking agreement with DFT, isolated from relaxation/geometry
+            # quality: MLIP single-point energy AT the DFT-relaxed structure,
+            # not the MLIP's own (possibly differently-converged) relaxed energy.
             spearmans_coefficient = spearmanr(
-                nv_initial_energies + sv_initial_energies,
+                nv_ref_structure_mlip_energies + sv_ref_structure_mlip_energies,
                 ref_nv_energies + ref_sv_energies,
             ).statistic
 

--- a/ml_peg/calcs/defects/split_vacancy/calc_split_vacancy.py
+++ b/ml_peg/calcs/defects/split_vacancy/calc_split_vacancy.py
@@ -10,7 +10,7 @@ from ase.io import read, write
 from ase.optimize import LBFGS
 import numpy as np
 from pymatgen.core import Structure
-from pymatgen.core.structure_matcher import StructureMatcher
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 import pytest
 from tqdm.auto import tqdm
 
@@ -30,7 +30,7 @@ OUT_PATH = Path(__file__).parent / "outputs"
 
 # based on MatBench settings, see https://github.com/janosh/matbench-discovery/issues/230
 # note we choose theshold stol for match in analysis
-STRUCTURE_MATCHER = StructureMatcher(stol=1.0, scale=False)
+STRUCTURE_MATCHER = StructureMatcher(stol=1.0, scale=False, comparator=ElementComparator())
 
 
 def get_rms_dist(atoms_1, atoms_2) -> tuple[float, float] | None:
@@ -82,20 +82,22 @@ def test_relax_and_calculate_energy(mlip: tuple[str, Any]):
                 p for p in material_dir.iterdir() if p.is_dir()
             ]  # skip pristine supercell.xyz files (not used)
             for cation_dir in tqdm(cation_dirs, leave=False):
-                nv_xyz_path = cation_dir / "normal_vacancy.xyz"
-                sv_xyz_path = cation_dir / "split_vacancy.xyz"
+                # "_initial" is the MLIP relaxation starting point (from doped)
+                #  "_ref" is the DFT-relaxed
+                atoms_paths = [
+                    (cation_dir / "normal_vacancy_initial.xyz", cation_dir / "normal_vacancy_ref.xyz", "normal_vacancy"),
+                    (cation_dir / "split_vacancy_initial.xyz", cation_dir / "split_vacancy_ref.xyz", "split_vacancy"),
+                ]
 
-                # many materials only have one of the two
-                # we could relax the one that exists and get max_dist
-                if not (nv_xyz_path.exists() and sv_xyz_path.exists()):
+                # many materials only have one of split and normal vacancy; skip if either is missing
+                if not all(p.exists() and r.exists() for p, r, _ in atoms_paths):
                     continue
 
-                atoms_paths = [nv_xyz_path, sv_xyz_path]
-
                 try:
-                    for atoms_path in atoms_paths:
+                    for atoms_path, ref_path, output_stem in atoms_paths:
                         relaxed_atoms = []
                         atoms_list = read(atoms_path, ":")
+                        ref_atoms_list = read(ref_path, ":")
 
                         ref_atoms_out_path = (
                             OUT_PATH
@@ -103,22 +105,37 @@ def test_relax_and_calculate_energy(mlip: tuple[str, Any]):
                             / "ref"
                             / material_dir.stem
                             / cation_dir.stem
-                            / f"{atoms_path.stem}.xyz"
+                            / f"{output_stem}.xyz"
                         )
                         # Copy ref structures once; later runs skip if present.
                         if not ref_atoms_out_path.exists():
                             ref_atoms_out_path.parent.mkdir(exist_ok=True, parents=True)
-                            write(ref_atoms_out_path, atoms_list)
+                            write(ref_atoms_out_path, ref_atoms_list)
 
-                        for initial_atoms in atoms_list:
+                        for initial_atoms, ref_atoms in zip(atoms_list, ref_atoms_list):
                             atoms = deepcopy(initial_atoms)
-                            atoms.info["charge"] = initial_atoms.info[
-                                "ref_total_charge"
-                            ]
+                            # some calculators (e.g. UMA) reject non-integer charge.
+                            atoms.info["charge"] = int(
+                                initial_atoms.info["ref_total_charge"]
+                            )
                             atoms.info["spin"] = 1
 
                             atoms.calc = deepcopy(calc)
                             atoms.info["initial_energy"] = atoms.get_potential_energy()
+
+                            # single-point MLIP energy at the (fixed) DFT-relaxed
+                            # geometry -- isolates energy-ranking (spearmans) agreement
+                            # from whether the MLIP's own relaxation finds a
+                            # good structure
+                            ref_eval_atoms = deepcopy(ref_atoms)
+                            ref_eval_atoms.info["charge"] = int(
+                                ref_atoms.info["ref_total_charge"]
+                            )
+                            ref_eval_atoms.info["spin"] = 1
+                            ref_eval_atoms.calc = deepcopy(calc)
+                            atoms.info["ref_structure_mlip_energy"] = (
+                                ref_eval_atoms.get_potential_energy()
+                            )
 
                             opt = LBFGS(atoms, logfile=None)
                             opt.run(fmax=fmax, steps=steps)
@@ -126,7 +143,7 @@ def test_relax_and_calculate_energy(mlip: tuple[str, Any]):
 
                             atoms.info["relaxed_energy"] = atoms.get_potential_energy()
 
-                            rmsd, max_dist = get_rms_dist(atoms, initial_atoms)
+                            rmsd, max_dist = get_rms_dist(atoms, ref_atoms)
                             atoms.info["ref_rmsd"] = rmsd
                             atoms.info["ref_max_distance"] = max_dist
                             atoms.info["relaxation_converged"] = converged
@@ -144,7 +161,7 @@ def test_relax_and_calculate_energy(mlip: tuple[str, Any]):
                             / model_name
                             / material_dir.stem
                             / cation_dir.stem
-                            / f"{atoms_path.stem}.xyz"
+                            / f"{output_stem}.xyz"
                         )
                         atoms_out_path.parent.mkdir(exist_ok=True, parents=True)
                         write(atoms_out_path, relaxed_atoms)

--- a/ml_peg/calcs/defects/split_vacancy/calc_split_vacancy.py
+++ b/ml_peg/calcs/defects/split_vacancy/calc_split_vacancy.py
@@ -30,7 +30,9 @@ OUT_PATH = Path(__file__).parent / "outputs"
 
 # based on MatBench settings, see https://github.com/janosh/matbench-discovery/issues/230
 # note we choose theshold stol for match in analysis
-STRUCTURE_MATCHER = StructureMatcher(stol=1.0, scale=False, comparator=ElementComparator())
+STRUCTURE_MATCHER = StructureMatcher(
+    stol=1.0, scale=False, comparator=ElementComparator()
+)
 
 
 def get_rms_dist(atoms_1, atoms_2) -> tuple[float, float] | None:
@@ -85,11 +87,19 @@ def test_relax_and_calculate_energy(mlip: tuple[str, Any]):
                 # "_initial" is the MLIP relaxation starting point (from doped)
                 #  "_ref" is the DFT-relaxed
                 atoms_paths = [
-                    (cation_dir / "normal_vacancy_initial.xyz", cation_dir / "normal_vacancy_ref.xyz", "normal_vacancy"),
-                    (cation_dir / "split_vacancy_initial.xyz", cation_dir / "split_vacancy_ref.xyz", "split_vacancy"),
+                    (
+                        cation_dir / "normal_vacancy_initial.xyz",
+                        cation_dir / "normal_vacancy_ref.xyz",
+                        "normal_vacancy",
+                    ),
+                    (
+                        cation_dir / "split_vacancy_initial.xyz",
+                        cation_dir / "split_vacancy_ref.xyz",
+                        "split_vacancy",
+                    ),
                 ]
 
-                # many materials only have one of split and normal vacancy; skip if either is missing
+                #  skip if either split or normal vacancy is missing
                 if not all(p.exists() and r.exists() for p, r, _ in atoms_paths):
                     continue
 
@@ -112,7 +122,9 @@ def test_relax_and_calculate_energy(mlip: tuple[str, Any]):
                             ref_atoms_out_path.parent.mkdir(exist_ok=True, parents=True)
                             write(ref_atoms_out_path, ref_atoms_list)
 
-                        for initial_atoms, ref_atoms in zip(atoms_list, ref_atoms_list):
+                        for initial_atoms, ref_atoms in zip(
+                            atoms_list, ref_atoms_list, strict=True
+                        ):
                             atoms = deepcopy(initial_atoms)
                             # some calculators (e.g. UMA) reject non-integer charge.
                             atoms.info["charge"] = int(


### PR DESCRIPTION
<!--
Thank you for contributing! To help us out with reviewing, please consider the following:

- Does this pull request include a summary of the change (see below)?
- Does this pull request include a descriptive title?
- Does this pull request link to an issue (see below)?
-->

## Pre-review checklist for PR author

PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines](https://github.com/ddmms/ml-peg/blob/main/contributing.md).
- [x] I have [reviewed and understand](https://ddmms.github.io/ml-peg/developer_guide/vibecoding.html#contributing-with-ai-the-vibe-coding-guide) all AI-generated code in this PR.
- [x] I have added human-written tests for the new logic.
- [x] I have properly cited any upstream algorithms or libraries the AI utilized.
- [x] I have disclosed significant AI tool usage in the PR description.

## Summary

- Instead of relaxing DFT-relaxed structures with MLIPs, relax the initial structures of the DFT relaxation.
    - This makes it harder to relax to the same structure.
- Spearman's (ranking) coefficient is calculated based on DFT relaxed structure. 
    - i.e. the ability of MLIPs to rank the energies of different DFT minima is assessed.
    - This makes this test somewhat independent of the geometry optimisations. 

## Linked issue

<!-- Enter the number of the issue this resolves. -->
Resolves #822 